### PR TITLE
Rmb proxy fixes

### DIFF
--- a/examples/resources/mounts/main.tf
+++ b/examples/resources/mounts/main.tf
@@ -18,7 +18,7 @@ resource "grid_network" "net1" {
 resource "grid_deployment" "d1" {
   node = 2
   network_name = grid_network.net1.name
-  ip_range = grid_network.net1.nodes_ip_range[2]
+  ip_range = lookup(grid_network.net1.nodes_ip_range, 2, "")
   disks {
     name = "data"
     size = 10

--- a/examples/resources/multinode/main.tf
+++ b/examples/resources/multinode/main.tf
@@ -20,7 +20,7 @@ resource "grid_network" "net1" {
 resource "grid_deployment" "d1" {
   node = 4
   network_name = grid_network.net1.name
-  ip_range = grid_network.net1.nodes_ip_range["4"]
+  ip_range = lookup(grid_network.net1.nodes_ip_range, 4, "")
   vms {
     name = "vm1"
     flist = "https://hub.grid.tf/tf-official-apps/base:latest.flist"
@@ -39,7 +39,7 @@ resource "grid_deployment" "d1" {
 resource "grid_deployment" "d2" {
   node = 2
   network_name = grid_network.net1.name
-  ip_range = grid_network.net1.nodes_ip_range["2"]
+  ip_range = lookup(grid_network.net1.nodes_ip_range, 2, "")
   vms {
     name = "vm3"
     flist = "https://hub.grid.tf/tf-official-apps/base:latest.flist"

--- a/examples/resources/qsfs/main.tf
+++ b/examples/resources/qsfs/main.tf
@@ -48,7 +48,7 @@ resource "grid_deployment" "d1" {
 resource "grid_deployment" "qsfs" {
   node = 7
   network_name = grid_network.net1.name
-  ip_range = grid_network.net1.nodes_ip_range[7]
+  ip_range = lookup(grid_network.net1.nodes_ip_range, 7, "")
   qsfs {
     name = "qsfs"
     description = "description6"

--- a/examples/resources/singlenode/main.tf
+++ b/examples/resources/singlenode/main.tf
@@ -19,7 +19,7 @@ resource "grid_network" "net1" {
 resource "grid_deployment" "d1" {
   node = 2
   network_name = grid_network.net1.name
-  ip_range = grid_network.net1.nodes_ip_range["2"]
+  ip_range = lookup(grid_network.net1.nodes_ip_range, 2, "")
   vms {
     name = "vm1"
     flist = "https://hub.grid.tf/tf-official-apps/base:latest.flist"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -87,7 +87,7 @@ func New(version string) func() *schema.Provider {
 					Type:        schema.TypeBool,
 					Optional:    true,
 					Description: "whether to use the rmb proxy or not",
-					DefaultFunc: schema.EnvDefaultFunc("USE_RMB_PROXY", nil),
+					DefaultFunc: schema.EnvDefaultFunc("USE_RMB_PROXY", true),
 				},
 			},
 			DataSourcesMap: map[string]*schema.Resource{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -165,16 +165,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	apiClient.use_rmb_proxy = d.Get("use_rmb_proxy").(bool)
 
 	apiClient.rmb_redis_url = d.Get("rmb_redis_url").(string)
-	var cl rmb.Client
-	if apiClient.use_rmb_proxy {
-		cl = client.NewProxyBus(apiClient.rmb_proxy_url, apiClient.twin_id)
-	} else {
-		cl, err = rmb.NewClient(apiClient.rmb_redis_url)
-	}
-	if err != nil {
-		return nil, diag.FromErr(errors.Wrap(err, "couldn't create rmb client"))
-	}
-	apiClient.rmb = cl
+
 	if err := validateAccount(&apiClient); err != nil {
 		return nil, diag.FromErr(err)
 	}
@@ -187,7 +178,16 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		return nil, diag.FromErr(errors.Wrap(err, "failed to get twin for the given mnemonics"))
 	}
 	apiClient.twin_id = twin
-
+	var cl rmb.Client
+	if apiClient.use_rmb_proxy {
+		cl = client.NewProxyBus(apiClient.rmb_proxy_url, apiClient.twin_id)
+	} else {
+		cl, err = rmb.NewClient(apiClient.rmb_redis_url)
+	}
+	if err != nil {
+		return nil, diag.FromErr(errors.Wrap(err, "couldn't create rmb client"))
+	}
+	apiClient.rmb = cl
 	if err := preValidate(&apiClient); err != nil {
 		return nil, diag.FromErr(err)
 	}

--- a/internal/provider/resource_deployment.go
+++ b/internal/provider/resource_deployment.go
@@ -1151,7 +1151,7 @@ func validate(d *schema.ResourceData) error {
 	ipRangeStr := d.Get("ip_range").(string)
 	networkName := d.Get("network_name").(string)
 	vms := d.Get("vms").([]interface{})
-	_, err := gridtypes.ParseIPNet(ipRangeStr)
+	_, _, err := net.ParseCIDR(ipRangeStr)
 	if len(vms) != 0 && err != nil {
 		return errors.Wrap(err, "If you pass a vm, ip_range must be set to a valid ip range (e.g. 10.1.3.0/16)")
 	}

--- a/internal/provider/resource_deployment.go
+++ b/internal/provider/resource_deployment.go
@@ -1168,7 +1168,7 @@ func resourceDeploymentUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(errors.Wrap(err, "error validating deployment"))
 	}
 	if d.HasChange("node") {
-		return diag.FromErr(errors.New("changing node is not supported, you need to destroy the deployment and reapply it again but you will lost your old data"))
+		return diag.FromErr(errors.New("changing node is not supported, you need to destroy the deployment and reapply it again but you will lose your old data"))
 	}
 	apiClient := meta.(*apiClient)
 	if err := validateAccountMoneyForExtrinsics(apiClient); err != nil {


### PR DESCRIPTION
- fix ip range validation (empty strings passed wasn't detected)
- twin id and rmb assignment order fixed
- change the direct ip_range map access to a lookup call to avoid "Invalid Index" which happens in cases like (change the node id in main.tf then call destroy).