### PR TITLE
add an in-between error between go error and terraform diagnostics

### DIFF
--- a/internal/provider/common.go
+++ b/internal/provider/common.go
@@ -86,7 +86,10 @@ func waitDeployment(ctx context.Context, nodeClient *client.NodeClient, deployme
 				}
 				return t.AsError()
 			}
-			lerr = err
+			if ctx.Err() != context.DeadlineExceeded {
+				// remember the error as long as we didn't time out
+				lerr = err
+			}
 		}
 	}
 }

--- a/internal/provider/data_source_gateway_domain.go
+++ b/internal/provider/data_source_gateway_domain.go
@@ -46,16 +46,16 @@ func dataSourceGatewayRead(ctx context.Context, d *schema.ResourceData, meta int
 	ncPool := NewNodeClient(apiClient.sub, apiClient.rmb)
 	nodeClient, err := ncPool.getNodeClient(nodeID)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "failed to get node client"))
+		return diagsFromErr(errors.Wrap(err, "failed to get node client"))
 	}
 	sub, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	cfg, err := nodeClient.NetworkGetPublicConfig(sub)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't get node public config"))
+		return diagsFromErr(errors.Wrap(err, "couldn't get node public config"))
 	}
 	if cfg.Domain == "" {
-		return diag.FromErr(errors.New("node doesn't contain a domain in its public config"))
+		return diagsFromErr(errors.New("node doesn't contain a domain in its public config"))
 	}
 	fqdn := fmt.Sprintf("%s.%s", name, cfg.Domain)
 	d.Set("fqdn", fqdn)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -133,11 +133,11 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		err = errors.New("key_type must be one of ed25519 and sr25519")
 	}
 	if err != nil {
-		return nil, diag.FromErr(errors.Wrap(err, "error getting identity"))
+		return nil, diagsFromErr(errors.Wrap(err, "error getting identity"))
 	}
 	sk, err := identity.KeyPair()
 	if err != nil {
-		return nil, diag.FromErr(errors.Wrap(err, "error getting user secret"))
+		return nil, diagsFromErr(errors.Wrap(err, "error getting user secret"))
 	}
 	apiClient.identity = identity
 	network := d.Get("network").(string)
@@ -158,14 +158,14 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	log.Printf("substrate url: %s %s\n", apiClient.substrate_url, substrate_url)
 	apiClient.sub, err = substrate.NewSubstrate(apiClient.substrate_url)
 	if err != nil {
-		return nil, diag.FromErr(errors.Wrap(err, "couldn't create substrate client"))
+		return nil, diagsFromErr(errors.Wrap(err, "couldn't create substrate client"))
 	}
 	apiClient.use_rmb_proxy = d.Get("use_rmb_proxy").(bool)
 
 	apiClient.rmb_redis_url = d.Get("rmb_redis_url").(string)
 
 	if err := validateAccount(&apiClient); err != nil {
-		return nil, diag.FromErr(err)
+		return nil, diagsFromErr(err)
 	}
 	pub := sk.Public()
 	twin, err := apiClient.sub.GetTwinByPubKey(pub)
@@ -173,7 +173,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		return nil, diag.Errorf("no twin associated with the accound with the given mnemonics")
 	}
 	if err != nil {
-		return nil, diag.FromErr(errors.Wrap(err, "failed to get twin for the given mnemonics"))
+		return nil, diagsFromErr(errors.Wrap(err, "failed to get twin for the given mnemonics"))
 	}
 	apiClient.twin_id = twin
 	var cl rmb.Client
@@ -184,11 +184,11 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	}
 	apiClient.grid_client = gridproxy.NewGridProxyClient(apiClient.rmb_proxy_url)
 	if err != nil {
-		return nil, diag.FromErr(errors.Wrap(err, "couldn't create rmb client"))
+		return nil, diagsFromErr(errors.Wrap(err, "couldn't create rmb client"))
 	}
 	apiClient.rmb = cl
 	if err := preValidate(&apiClient); err != nil {
-		return nil, diag.FromErr(err)
+		return nil, diagsFromErr(err)
 	}
 	return &apiClient, nil
 }

--- a/internal/provider/resource_deployment.go
+++ b/internal/provider/resource_deployment.go
@@ -917,24 +917,24 @@ func (dep *DeploymentDeployer) storeState(d *schema.ResourceData) {
 func resourceDeploymentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	err := validate(d)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error validating deployment"))
+		return diagsFromErr(errors.Wrap(err, "error validating deployment"))
 	}
 	apiClient := meta.(*apiClient)
 	if err := validateAccountMoneyForExtrinsics(apiClient); err != nil {
-		return diag.FromErr(err)
+		return diagsFromErr(err)
 	}
 	rmbctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	go startRmbIfNeeded(rmbctx, apiClient)
 	deployer, err := getDeploymentDeployer(d, apiClient)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't load deployer data"))
+		return diagsFromErr(errors.Wrap(err, "couldn't load deployer data"))
 	}
 
 	var diags diag.Diagnostics
 	deploymentID, err := deployer.Deploy(ctx)
 	if err != nil {
-		return diag.FromErr(err)
+		return diagsFromErr(err)
 	}
 	deployer.storeState(d)
 	d.SetId(strconv.FormatUint(uint64(deploymentID), 10))
@@ -1039,7 +1039,7 @@ func resourceDeploymentRead(ctx context.Context, d *schema.ResourceData, meta in
 	var diags diag.Diagnostics
 	sub, err := substrate.NewSubstrate(apiClient.substrate_url)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error getting substrate client"))
+		return diagsFromErr(errors.Wrap(err, "error getting substrate client"))
 	}
 	nodeID := uint32(d.Get("node").(int))
 	nodeInfo, err := sub.GetNode(nodeID)
@@ -1171,27 +1171,27 @@ func validate(d *schema.ResourceData) error {
 func resourceDeploymentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	err := validate(d)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error validating deployment"))
+		return diagsFromErr(errors.Wrap(err, "error validating deployment"))
 	}
 	if d.HasChange("node") {
-		return diag.FromErr(errors.New("changing node is not supported, you need to destroy the deployment and reapply it again but you will lose your old data"))
+		return diagsFromErr(errors.New("changing node is not supported, you need to destroy the deployment and reapply it again but you will lose your old data"))
 	}
 	apiClient := meta.(*apiClient)
 	if err := validateAccountMoneyForExtrinsics(apiClient); err != nil {
-		return diag.FromErr(err)
+		return diagsFromErr(err)
 	}
 	rmbctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	go startRmbIfNeeded(rmbctx, apiClient)
 	deployer, err := getDeploymentDeployer(d, apiClient)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't load deployer data"))
+		return diagsFromErr(errors.Wrap(err, "couldn't load deployer data"))
 	}
 
 	var diags diag.Diagnostics
 	_, err = deployer.Deploy(ctx)
 	if err != nil {
-		return diag.FromErr(err)
+		return diagsFromErr(err)
 	}
 	deployer.storeState(d)
 	return diags
@@ -1214,20 +1214,20 @@ func (d *DeploymentDeployer) Cancel(ctx context.Context) error {
 func resourceDeploymentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	apiClient := meta.(*apiClient)
 	if err := validateAccountMoneyForExtrinsics(apiClient); err != nil {
-		return diag.FromErr(err)
+		return diagsFromErr(err)
 	}
 	rmbctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	go startRmbIfNeeded(rmbctx, apiClient)
 	deployer, err := getDeploymentDeployer(d, apiClient)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't load deployer data"))
+		return diagsFromErr(errors.Wrap(err, "couldn't load deployer data"))
 	}
 
 	var diags diag.Diagnostics
 	err = deployer.Cancel(ctx)
 	if err != nil {
-		diags = diag.FromErr(err)
+		diags = diagsFromErr(err)
 	}
 	if err == nil {
 		d.SetId("")

--- a/internal/provider/resource_gateway_fqdn.go
+++ b/internal/provider/resource_gateway_fqdn.go
@@ -240,18 +240,18 @@ func resourceGatewayFQDNCreate(ctx context.Context, d *schema.ResourceData, meta
 	go startRmbIfNeeded(rmbctx, apiClient)
 	deployer, err := NewGatewayFQDNDeployer(ctx, d, apiClient)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't load deployer data"))
+		return diagsFromErr(errors.Wrap(err, "couldn't load deployer data"))
 	}
 	if err := deployer.Validate(ctx); err != nil {
-		return diag.FromErr(err)
+		return diagsFromErr(err)
 	}
 	err = deployer.Deploy(ctx)
 	if err != nil {
 		if len(deployer.NodeDeploymentID) != 0 {
 			// failed to deploy and failed to revert, store the current state locally
-			diags = diag.FromErr(err)
+			diags = diagsFromErr(err)
 		} else {
-			return diag.FromErr(err)
+			return diagsFromErr(err)
 		}
 	}
 	deployer.storeState(d)
@@ -268,16 +268,16 @@ func resourceGatewayFQDNUpdate(ctx context.Context, d *schema.ResourceData, meta
 	go startRmbIfNeeded(rmbctx, apiClient)
 	deployer, err := NewGatewayFQDNDeployer(ctx, d, apiClient)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't load deployer data"))
+		return diagsFromErr(errors.Wrap(err, "couldn't load deployer data"))
 	}
 
 	if err := deployer.Validate(ctx); err != nil {
-		return diag.FromErr(err)
+		return diagsFromErr(err)
 	}
 
 	err = deployer.Deploy(ctx)
 	if err != nil {
-		diags = diag.FromErr(err)
+		diags = diagsFromErr(err)
 	}
 	deployer.storeState(d)
 	return diags
@@ -292,7 +292,7 @@ func resourceGatewayFQDNRead(ctx context.Context, d *schema.ResourceData, meta i
 	go startRmbIfNeeded(rmbctx, apiClient)
 	deployer, err := NewGatewayFQDNDeployer(ctx, d, apiClient)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't load deployer data"))
+		return diagsFromErr(errors.Wrap(err, "couldn't load deployer data"))
 	}
 
 	err = deployer.updateFromRemote(ctx)
@@ -317,11 +317,11 @@ func resourceGatewayFQDNDelete(ctx context.Context, d *schema.ResourceData, meta
 	go startRmbIfNeeded(rmbctx, apiClient)
 	deployer, err := NewGatewayFQDNDeployer(ctx, d, apiClient)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't load deployer data"))
+		return diagsFromErr(errors.Wrap(err, "couldn't load deployer data"))
 	}
 	err = deployer.Cancel(ctx)
 	if err != nil {
-		diags = diag.FromErr(err)
+		diags = diagsFromErr(err)
 	}
 	if err == nil {
 		d.SetId("")

--- a/internal/provider/resource_gateway_name.go
+++ b/internal/provider/resource_gateway_name.go
@@ -274,18 +274,18 @@ func resourceGatewayNameCreate(ctx context.Context, d *schema.ResourceData, meta
 	go startRmbIfNeeded(rmbctx, apiClient)
 	deployer, err := NewGatewayNameDeployer(ctx, d, apiClient)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't load deployer data"))
+		return diagsFromErr(errors.Wrap(err, "couldn't load deployer data"))
 	}
 	if err := deployer.Validate(ctx); err != nil {
-		return diag.FromErr(err)
+		return diagsFromErr(err)
 	}
 	err = deployer.Deploy(ctx)
 	if err != nil {
 		if len(deployer.NodeDeploymentID) != 0 {
 			// failed to deploy and failed to revert, store the current state locally
-			diags = diag.FromErr(err)
+			diags = diagsFromErr(err)
 		} else {
-			return diag.FromErr(err)
+			return diagsFromErr(err)
 		}
 	}
 	deployer.storeState(d)
@@ -302,16 +302,16 @@ func resourceGatewayNameUpdate(ctx context.Context, d *schema.ResourceData, meta
 	go startRmbIfNeeded(rmbctx, apiClient)
 	deployer, err := NewGatewayNameDeployer(ctx, d, apiClient)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't load deployer data"))
+		return diagsFromErr(errors.Wrap(err, "couldn't load deployer data"))
 	}
 
 	if err := deployer.Validate(ctx); err != nil {
-		return diag.FromErr(err)
+		return diagsFromErr(err)
 	}
 
 	err = deployer.Deploy(ctx)
 	if err != nil {
-		diags = diag.FromErr(err)
+		diags = diagsFromErr(err)
 	}
 	deployer.storeState(d)
 	return diags
@@ -326,7 +326,7 @@ func resourceGatewayNameRead(ctx context.Context, d *schema.ResourceData, meta i
 	go startRmbIfNeeded(rmbctx, apiClient)
 	deployer, err := NewGatewayNameDeployer(ctx, d, apiClient)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't load deployer data"))
+		return diagsFromErr(errors.Wrap(err, "couldn't load deployer data"))
 	}
 
 	err = deployer.updateFromRemote(ctx)
@@ -351,11 +351,11 @@ func resourceGatewayNameDelete(ctx context.Context, d *schema.ResourceData, meta
 	go startRmbIfNeeded(rmbctx, apiClient)
 	deployer, err := NewGatewayNameDeployer(ctx, d, apiClient)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't load deployer data"))
+		return diagsFromErr(errors.Wrap(err, "couldn't load deployer data"))
 	}
 	err = deployer.Cancel(ctx)
 	if err != nil {
-		diags = diag.FromErr(err)
+		diags = diagsFromErr(err)
 	}
 	if err == nil {
 		d.SetId("")

--- a/internal/provider/resource_k8s.go
+++ b/internal/provider/resource_k8s.go
@@ -858,20 +858,20 @@ func resourceK8sCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	go startRmbIfNeeded(rmbctx, apiClient)
 	deployer, err := NewK8sDeployer(d, apiClient)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't load deployer data"))
+		return diagsFromErr(errors.Wrap(err, "couldn't load deployer data"))
 	}
 
 	if err := deployer.Validate(ctx); err != nil {
-		return diag.FromErr(err)
+		return diagsFromErr(err)
 	}
 
 	err = deployer.Deploy(ctx)
 	if err != nil {
 		if len(deployer.NodeDeploymentID) != 0 {
 			// failed to deploy and failed to revert, store the current state locally
-			diags = diag.FromErr(err)
+			diags = diagsFromErr(err)
 		} else {
-			return diag.FromErr(err)
+			return diagsFromErr(err)
 		}
 	}
 	deployer.storeState(d)
@@ -887,20 +887,20 @@ func resourceK8sUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 	go startRmbIfNeeded(rmbctx, apiClient)
 	deployer, err := NewK8sDeployer(d, apiClient)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't load deployer data"))
+		return diagsFromErr(errors.Wrap(err, "couldn't load deployer data"))
 	}
 
 	if err := deployer.Validate(ctx); err != nil {
-		return diag.FromErr(err)
+		return diagsFromErr(err)
 	}
 
 	if err := deployer.invalidateBrokenAttributes(); err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't invalidate broken attributes"))
+		return diagsFromErr(errors.Wrap(err, "couldn't invalidate broken attributes"))
 	}
 
 	err = deployer.Deploy(ctx)
 	if err != nil {
-		diags = diag.FromErr(err)
+		diags = diagsFromErr(err)
 	}
 	deployer.storeState(d)
 	return diags
@@ -914,15 +914,15 @@ func resourceK8sRead(ctx context.Context, d *schema.ResourceData, meta interface
 	go startRmbIfNeeded(rmbctx, apiClient)
 	deployer, err := NewK8sDeployer(d, apiClient)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't load deployer data"))
+		return diagsFromErr(errors.Wrap(err, "couldn't load deployer data"))
 	}
 
 	if err := deployer.Validate(ctx); err != nil {
-		return diag.FromErr(err)
+		return diagsFromErr(err)
 	}
 
 	if err := deployer.invalidateBrokenAttributes(); err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't invalidate broken attributes"))
+		return diagsFromErr(errors.Wrap(err, "couldn't invalidate broken attributes"))
 	}
 
 	err = deployer.updateFromRemote(ctx)
@@ -947,12 +947,12 @@ func resourceK8sDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 	go startRmbIfNeeded(rmbctx, apiClient)
 	deployer, err := NewK8sDeployer(d, apiClient)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't load deployer data"))
+		return diagsFromErr(errors.Wrap(err, "couldn't load deployer data"))
 	}
 
 	err = deployer.Cancel(ctx)
 	if err != nil {
-		diags = diag.FromErr(err)
+		diags = diagsFromErr(err)
 	}
 	if err == nil {
 		d.SetId("")

--- a/internal/provider/resource_network.go
+++ b/internal/provider/resource_network.go
@@ -668,18 +668,18 @@ func resourceNetworkCreate(ctx context.Context, d *schema.ResourceData, meta int
 	go startRmbIfNeeded(rmbctx, apiClient)
 	deployer, err := NewNetworkDeployer(ctx, d, apiClient)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't load deployer data"))
+		return diagsFromErr(errors.Wrap(err, "couldn't load deployer data"))
 	}
 	if err := deployer.Validate(ctx); err != nil {
-		return diag.FromErr(err)
+		return diagsFromErr(err)
 	}
 	err = deployer.Deploy(ctx)
 	if err != nil {
 		if len(deployer.NodeDeploymentID) != 0 {
 			// failed to deploy and failed to revert, store the current state locally
-			diags = diag.FromErr(err)
+			diags = diagsFromErr(err)
 		} else {
-			return diag.FromErr(err)
+			return diagsFromErr(err)
 		}
 	}
 	deployer.storeState(d)
@@ -696,19 +696,19 @@ func resourceNetworkUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	go startRmbIfNeeded(rmbctx, apiClient)
 	deployer, err := NewNetworkDeployer(ctx, d, apiClient)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't load deployer data"))
+		return diagsFromErr(errors.Wrap(err, "couldn't load deployer data"))
 	}
 
 	if err := deployer.Validate(ctx); err != nil {
-		return diag.FromErr(err)
+		return diagsFromErr(err)
 	}
 	if err := deployer.invalidateBrokenAttributes(); err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't invalidate broken attributes"))
+		return diagsFromErr(errors.Wrap(err, "couldn't invalidate broken attributes"))
 	}
 
 	err = deployer.Deploy(ctx)
 	if err != nil {
-		diags = diag.FromErr(err)
+		diags = diagsFromErr(err)
 	}
 	deployer.storeState(d)
 	return diags
@@ -723,11 +723,11 @@ func resourceNetworkRead(ctx context.Context, d *schema.ResourceData, meta inter
 	go startRmbIfNeeded(rmbctx, apiClient)
 	deployer, err := NewNetworkDeployer(ctx, d, apiClient)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't load deployer data"))
+		return diagsFromErr(errors.Wrap(err, "couldn't load deployer data"))
 	}
 
 	if err := deployer.invalidateBrokenAttributes(); err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't invalidate broken attributes"))
+		return diagsFromErr(errors.Wrap(err, "couldn't invalidate broken attributes"))
 	}
 
 	err = deployer.readNodesConfig(ctx)
@@ -751,11 +751,11 @@ func resourceNetworkDelete(ctx context.Context, d *schema.ResourceData, meta int
 	go startRmbIfNeeded(rmbctx, apiClient)
 	deployer, err := NewNetworkDeployer(ctx, d, apiClient)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "couldn't load deployer data"))
+		return diagsFromErr(errors.Wrap(err, "couldn't load deployer data"))
 	}
 	err = deployer.Cancel(ctx)
 	if err != nil {
-		diags = diag.FromErr(err)
+		diags = diagsFromErr(err)
 	}
 	if err == nil {
 		d.SetId("")

--- a/internal/provider/resource_scheduler.go
+++ b/internal/provider/resource_scheduler.go
@@ -221,7 +221,7 @@ func schedule(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 	go startRmbIfNeeded(ctx, apiClient)
 	nodes, err := getNodes(apiClient.rmb_proxy_url)
 	if err != nil {
-		return diag.FromErr(err)
+		return diagsFromErr(err)
 	}
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(nodes), func(i, j int) { nodes[i], nodes[j] = nodes[j], nodes[i] })
@@ -270,7 +270,7 @@ func schedule(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 		}
 		if _, ok := assignment[r.Name]; !ok {
 			json.NewEncoder(log.Writer()).Encode(r)
-			return diag.FromErr(fmt.Errorf("didn't find a suitable node"))
+			return diagsFromErr(fmt.Errorf("didn't find a suitable node"))
 		}
 	}
 	d.Set("nodes", assignment)

--- a/internal/terrors.go
+++ b/internal/terrors.go
@@ -1,0 +1,121 @@
+package internal
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/pkg/errors"
+)
+
+/* 	usage:
+ * 	func test() (uint32, error) {
+ *   	t = NewTerror()
+ *		if err := another(); err != nil {
+ *			t = t.AppendErr(err)
+ *			return 0, t
+ *		}
+ *		if err := anotherDiags(); err.HasErrors() {
+ *			t = t.Append(err)
+ *			return 0, t
+ *		}
+ *		for i := 1; i < 5; i++ {
+ *			if err := check(i); err != nil {
+ *				t = t.AppendErr(err)
+ *			}
+ *		}
+ *		return 0, t.AsNullIfEmpty()
+ *	}
+ */
+
+type Terror struct {
+	diag.Diagnostics
+}
+
+func severityString(s diag.Severity) string {
+	if s == diag.Error {
+		return "Error"
+	} else {
+		return "Warn"
+	}
+}
+func NewTerror() *Terror {
+	return &Terror{Diagnostics: make(diag.Diagnostics, 0)}
+}
+func encodeDiagnostic(d diag.Diagnostic) string {
+	if d.Detail == "" {
+		return fmt.Sprintf("%s: %s", severityString(d.Severity), d.Summary)
+	} else {
+		return fmt.Sprintf("%s: %s\nDetails: %s", severityString(d.Severity), d.Summary, d.Detail)
+	}
+}
+func (t *Terror) HasError() bool {
+	return t.Diagnostics.HasError()
+}
+func (t *Terror) Append(d diag.Diagnostic) {
+	if t == nil {
+		return
+	}
+	t.Diagnostics = append(t.Diagnostics, d)
+}
+
+func (t *Terror) AppendErr(err error) {
+	if t == nil || err == nil {
+		return
+	}
+	if e, ok := err.(*Terror); ok {
+		t.Diagnostics = append(t.Diagnostics, e.Diagnostics...)
+	} else {
+		t.Diagnostics = append(t.Diagnostics, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  err.Error(),
+		})
+	}
+}
+
+func (t *Terror) AppendWrappedErr(err error, nerr string, args ...interface{}) {
+	if t == nil || err == nil {
+		return
+	}
+	if e, ok := err.(*Terror); ok {
+		for _, d := range e.Diagnostics {
+			t.Diagnostics = append(t.Diagnostics, diag.Diagnostic{
+				Severity: d.Severity,
+				Summary:  fmt.Sprintf("%s: %s", fmt.Sprintf(nerr, args...), d.Summary),
+				Detail:   d.Detail,
+			})
+		}
+	} else {
+		t.Diagnostics = append(t.Diagnostics, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  errors.Wrapf(err, nerr, args...).Error(),
+		})
+	}
+}
+
+func (t *Terror) Error() string {
+	if t == nil || len(t.Diagnostics) == 0 {
+		return "nothing bad happened, if you are presented with error, it's probably a plugin bug"
+	} else if len(t.Diagnostics) == 1 {
+		return encodeDiagnostic(t.Diagnostics[0])
+	} else {
+		result := "The following diagnostics occured:"
+		for _, d := range t.Diagnostics {
+			result = fmt.Sprintf("%s\n\n%s", result, encodeDiagnostic(d))
+		}
+		return result
+	}
+}
+
+func (t *Terror) Diags() diag.Diagnostics {
+	if t == nil {
+		return nil
+	}
+	return t.Diagnostics
+}
+
+func (t *Terror) AsError() error {
+	if t == nil || len(t.Diagnostics) == 0 {
+		return nil
+	}
+	return t
+}

--- a/internal/terrors.go
+++ b/internal/terrors.go
@@ -23,7 +23,7 @@ import (
  *				t = t.AppendErr(err)
  *			}
  *		}
- *		return 0, t.AsNullIfEmpty()
+ *		return 0, t.AsError()
  *	}
  */
 


### PR DESCRIPTION
So terraform has a `Diagnostics` which is a list of `Diagnostic`, it has a summary and detail and is reported nicely by the plugin. Go however has a different way(?) of handling errors, which is wrapping. This poses a problem when multiple workloads fail for example, concatenating all of them is not user-friendly. The deployment workload failure and node checks are modified to work with it.

Another wrapper type is created in this pr around the `Diagnostics` type to support transitioning from using go errors to using terraform diagnostics. The new type can wrap other errors nicely and can wrap itself. Go errors can wrap the new type but the error message will not be good. So if a method needs to handle the errors in terraform way, all its callers and grand callers must do in it in terraform way. Another problem (not current but can be in the future), is that `errors.Is()` won't work anymore.

Diagnostics new view:
![image](https://user-images.githubusercontent.com/13040543/147474974-12fdbcaa-6509-4cb0-a9bc-ef76564f31f8.png)