### PR TITLE
V0.1.28

### DIFF
--- a/examples/resources/cosmosvalidator/main.tf
+++ b/examples/resources/cosmosvalidator/main.tf
@@ -1,0 +1,57 @@
+terraform {
+  required_providers {
+    grid = {
+      source = "threefoldtech/grid"
+    }
+  }
+}
+
+provider "grid" {
+}
+
+resource "grid_network" "net1" {
+    nodes = [8]
+    ip_range = "10.1.0.0/16"
+    name = "networkkkky"
+    description = "newer network"
+    add_wg_access = true
+}
+resource "grid_deployment" "d1" {
+  node = 8
+  network_name = grid_network.net1.name
+  ip_range = lookup(grid_network.net1.nodes_ip_range, 8, "")
+  vms {
+    name = "vm1"
+    flist = "https://hub.grid.tf/ashraf.3bot/ashraffouda-threefold_hub-latest.flist"
+    cpu = 2 
+    publicip = true
+    memory = 4096
+    entrypoint = "/sbin/zinit init"
+    env_vars = {
+      SSH_KEY = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTwULSsUubOq3VPWL6cdrDvexDmjfznGydFPyaNcn7gAL9lRxwFbCDPMj7MbhNSpxxHV2+/iJPQOTVJu4oc1N7bPP3gBCnF51rPrhTpGCt5pBbTzeyNweanhedkKDsCO2mIEh/92Od5Hg512dX4j7Zw6ipRWYSaepapfyoRnNSriW/s3DH/uewezVtL5EuypMdfNngV/u2KZYWoeiwhrY/yEUykQVUwDysW/xUJNP5o+KSTAvNSJatr3FbuCFuCjBSvageOLHePTeUwu6qjqe+Xs4piF1ByO/6cOJ8bt5Vcx0bAtI8/MPApplUU/JWevsPNApvnA/ntffI+u8DCwgP ashraf@thinkpad"
+
+      MNEMONICS="<MNEMONICS>"
+      KEYNAME="ashraaf"
+      STAKE_AMOUNT="100000000stake"
+      MONIKER="ashroofdfd"
+      CHAIN_ID="threefold-hub"
+      ETHEREUM_ADDRESS="ETHEREUM_ADDRESS"
+      ETHEREUM_PRIV_KEY="<ETHEREUM_PRIVATE_KEY>"
+      GRAVITY_ADDRESS="GRAVIRY CONTRACT ADDRESS"
+      ETHEREUM_RPC="http://<IP>:8575"
+      PERSISTENT_PEERS="780e271b5a835722ba0fac1c979e54d078e57e38@161.35.85.34:26656"
+      GENESIS_URL="https://gist.githubusercontent.com/ashraffouda/1e494d95ad60ed8f72805c47a0493da7/raw/9955c1488dabd1bdcdeb60f12b1120b1ae3a74ca/genesis.json"
+    }
+    planetary = true
+  }
+}
+output "wg_config" {
+    value = grid_network.net1.access_wg_config
+}
+output "node1_zmachine1_ip" {
+    value = grid_deployment.d1.vms[0].ip
+}
+
+output "ygg_ip" {
+    value = grid_deployment.d1.vms[0].ygg_ip
+}

--- a/examples/resources/presearch/README.md
+++ b/examples/resources/presearch/README.md
@@ -1,0 +1,30 @@
+## Presearch
+
+- Create a registration code from presearch [dashboard](https://nodes.presearch.org/dashboard)
+- Only provide restoring keys pair if you want to restore old node or leave empty.
+
+NOTE: restoring keys pair must follow this schema
+
+```bash
+    PRESEARCH_BACKUP_PRI_KEY = <<EOF
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDQjfuZ3uIGOXUP
+Qqpw1K85LV6sZWOAntUnhL73GXTWcwBer06yPI1ush8Vj6tdP94hmUFfWW85vYRU
+...
+-----END PRIVATE KEY-----
+      EOF
+      PRESEARCH_BACKUP_PUB_KEY = <<EOF
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0I37md7iBjl1D0KqcNSv
+OS1erGVjgJ7VJ4S+9xl01nMAXq9OsjyNbrIfFY+rXT/eIZlBX1lvOb2EVJ93o1mz
+...
+-----END PUBLIC KEY-----
+      EOF
+```
+
+## Requirments
+
+- 1 CPU
+- 1 GB RAM
+- 10 GB storage
+- public ip

--- a/examples/resources/presearch/main.tf
+++ b/examples/resources/presearch/main.tf
@@ -1,0 +1,82 @@
+terraform {
+  required_providers {
+    grid = {
+      source = "threefoldtech/grid"
+    }
+  }
+}
+
+provider "grid" {
+}
+
+resource "grid_network" "net1" {
+  nodes         = [8]
+  ip_range      = "10.1.0.0/16"
+  name          = "network"
+  description   = "newer network"
+  add_wg_access = true
+}
+
+# Deployment specs
+resource "grid_deployment" "d1" {
+  node         = 8
+  network_name = grid_network.net1.name
+  ip_range     = lookup(grid_network.net1.nodes_ip_range, 8, "")
+
+  disks {
+    name        = "data"
+    size        = 10
+    description = "volume holding docker data"
+  }
+
+  vms {
+    name       = "presearch"
+    flist      = "https://hub.grid.tf/omarabdul3ziz.3bot/omarabdul3ziz-presearch-v2.2.flist"
+    entrypoint = "/sbin/zinit init"
+    publicip   = true
+    planetary  = true
+    cpu        = 1
+    memory     = 1024
+
+    mounts {
+      disk_name   = "data"
+      mount_point = "/var/lib/docker"
+    }
+
+    env_vars = {
+      SSH_KEY                     = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDZnBgLQt77C1suFHsBH5sNdbTxcCCiowDPB+U8h0OsT7onOg/HCYGEguUh9yl5VlacODXSexBhg9LsFTDuO/nBTf/DQVpjqRGQs1QenoGrpaxxaI5Svo5GBLE3Jogva/fhbJtwK9yEgW+1zltO3rTp+sdQ7JFG3uZGnlLSN1U+PCJVzONM2BaAGkQ6XHHuCCiisMlNgWXUzN3T+DjkzHWbXyqPEoK/gSkV20QzWbDRzxM/FJNIOZZh70H+n3QcSl9Q5VTfhc2K1rMNnGRQrl2QHcBsPoO/8dYJxKGt/u9pZI3wkE5C0coYtNvfXIcNj7cSsSJIvCdYYl6x4LkxXhwrOomOwmtZTmJEewe0nhClDU4gMm4s3eET7j2GPe73Ft2OVuF9j+3z0K3jUFQ/2m3HmDDtNVYlB7IOL5479cLRfBBvvQuNpd0p1yBUopxoBureFdqgZYa5887BcUENOKiR58JgF1mZ15g4nnUrdkXqm7KhQgniAp9E68MdsJEg9t0= omar@jarvis",
+      PRESEARCH_REGISTRATION_CODE = "",
+
+      # optional keys pair from the old node 
+      # important to follow the schema ` <<-EOF ... EOF ` with no indentation
+      PRESEARCH_BACKUP_PRI_KEY = <<EOF
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDQjfuZ3uIGOXUP
+Qqpw1K85LV6sZWOAntUnhL73GXTWcwBer06yPI1ush8Vj6tdP94hmUFfWW85vYRU
+...
+-----END PRIVATE KEY-----
+      EOF
+      PRESEARCH_BACKUP_PUB_KEY = <<EOF
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0I37md7iBjl1D0KqcNSv
+OS1erGVjgJ7VJ4S+9xl01nMAXq9OsjyNbrIfFY+rXT/eIZlBX1lvOb2EVJ93o1mz
+...
+-----END PUBLIC KEY-----
+      EOF
+    }
+  }
+}
+
+
+# Print deployment info
+output "node1_zmachine1_ip" {
+  value = grid_deployment.d1.vms[0].ip
+}
+
+output "public_ip" {
+  value = grid_deployment.d1.vms[0].computedip
+}
+
+output "ygg_ip" {
+  value = grid_deployment.d1.vms[0].ygg_ip
+}

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,9 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.7.1
 	github.com/threefoldtech/go-rmb v0.1.11-0.20220224131627-825c23c921d3
-	github.com/threefoldtech/substrate-client v0.0.0-20220328075445-99d0ff259160
+	github.com/threefoldtech/substrate-client v0.0.0-20220509081306-42520ab2c1a1
 	github.com/threefoldtech/zos v0.5.6-0.20220308141056-258859a3efe6
 	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20210803171230-4253848d036c
@@ -34,6 +35,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deckarep/golang-set v1.8.0 // indirect
 	github.com/decred/base58 v1.0.3 // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect
@@ -87,6 +89,7 @@ require (
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pierrec/xxHash v0.1.5 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/rs/cors v1.8.2 // indirect
 	github.com/rs/zerolog v1.26.0 // indirect
@@ -106,6 +109,7 @@ require (
 	google.golang.org/grpc v1.41.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
 replace github.com/centrifuge/go-substrate-rpc-client/v4 v4.0.0 => github.com/threefoldtech/go-substrate-rpc-client/v4 v4.0.1-0.20220224103912-af82b63a1bda

--- a/go.sum
+++ b/go.sum
@@ -1172,8 +1172,9 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
@@ -1188,8 +1189,8 @@ github.com/threefoldtech/go-substrate-rpc-client/v4 v4.0.1-0.20220224103912-af82
 github.com/threefoldtech/go-substrate-rpc-client/v4 v4.0.1-0.20220224103912-af82b63a1bda/go.mod h1:Mo1w5OuYcq6hYiNQx+GCg8ot8UEXg4OHlej19kdFCZk=
 github.com/threefoldtech/substrate-client v0.0.0-20220224131248-f56a2e9fa1d4/go.mod h1:Lpsz7gVNSdbWD8erfVh1AZv2wnProc7g/QHJiYp5lP8=
 github.com/threefoldtech/substrate-client v0.0.0-20220308140931-04dc2e0dad45/go.mod h1:Lpsz7gVNSdbWD8erfVh1AZv2wnProc7g/QHJiYp5lP8=
-github.com/threefoldtech/substrate-client v0.0.0-20220328075445-99d0ff259160 h1:22yuKo4cWd5xx0NEsKRMFp/aI6L7j9be9Zsby+Q1z+w=
-github.com/threefoldtech/substrate-client v0.0.0-20220328075445-99d0ff259160/go.mod h1:Lpsz7gVNSdbWD8erfVh1AZv2wnProc7g/QHJiYp5lP8=
+github.com/threefoldtech/substrate-client v0.0.0-20220509081306-42520ab2c1a1 h1:FeVHMu9yWf35ikqNmWB+Hke+2K5dAmBlNUFo8+9Li6M=
+github.com/threefoldtech/substrate-client v0.0.0-20220509081306-42520ab2c1a1/go.mod h1:Lpsz7gVNSdbWD8erfVh1AZv2wnProc7g/QHJiYp5lP8=
 github.com/threefoldtech/zbus v0.1.5/go.mod h1:ZtiRpcqzEBJetVQDsEbw0p48h/AF3O1kf0tvd30I0BU=
 github.com/threefoldtech/zos v0.5.6-0.20220308141056-258859a3efe6 h1:9fMwgPCpaP9KoiZCyNVVmWO8rj+T559M+yBXWg8XJn0=
 github.com/threefoldtech/zos v0.5.6-0.20220308141056-258859a3efe6/go.mod h1:bwe05keuu+u3D05c1+ia/9n0GWB5Xgtw0SIh1MPYQdE=

--- a/internal/gridproxy/grid_client_test.go
+++ b/internal/gridproxy/grid_client_test.go
@@ -1,0 +1,270 @@
+package gridproxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+var (
+	NodeExampleStr       = `{"id":"0000000510-000001-782e1","nodeId":1,"farmId":1,"twinId":9,"country":"Belgium","gridVersion":3,"city":"Unknown","uptime":1297882,"created":1649252220,"farmingPolicyId":1,"updatedAt":1650550422,"total_resources":{"cru":24,"sru":512110190592,"hru":9001778946048,"mru":202802933760},"used_resources":{"cru":52,"sru":793419710464,"hru":0,"mru":119957094400},"location":{"country":"Belgium","city":"Unknown"},"publicConfig":{"domain":"","gw4":"","gw6":"","ipv4":"","ipv6":""},"status":"up","certificationType":"Diy"}`
+	NodesExampleStr      = fmt.Sprintf("[%s]", NodeExampleStr)
+	FarmExampleStr       = `{"name":"Freefarm","farmId":1,"twinId":2,"pricingPolicyId":1,"stellarAddress":"","publicIps":[{"id":"0000001006-000001-f899f","ip":"185.206.122.35/24","farmId":"","contractId":142,"gateway":"185.206.122.1"},{"id":"0000001012-000001-23923","ip":"185.206.122.36/24","farmId":"","contractId":317,"gateway":"185.206.122.1"},{"id":"0000001019-000001-5001b","ip":"185.206.122.37/24","farmId":"","contractId":144,"gateway":"185.206.122.1"},{"id":"0000001070-000001-3e7e7","ip":"185.206.122.42/24","farmId":"","contractId":0,"gateway":"185.206.122.1"},{"id":"0000001047-000001-f6e0d","ip":"185.206.122.41/24","farmId":"","contractId":0,"gateway":"185.206.122.1"},{"id":"0000001042-000001-f65e8","ip":"185.206.122.40/24","farmId":"","contractId":0,"gateway":"185.206.122.1"},{"id":"0000000991-000001-aa42e","ip":"185.206.122.33/24","farmId":"","contractId":164,"gateway":"185.206.122.1"},{"id":"0000001037-000001-dad97","ip":"185.206.122.39/24","farmId":"","contractId":619,"gateway":"185.206.122.1"},{"id":"0000001075-000001-3b1ee","ip":"185.206.122.43/24","farmId":"","contractId":0,"gateway":"185.206.122.1"},{"id":"0000001084-000001-670af","ip":"185.206.122.44/24","farmId":"","contractId":0,"gateway":"185.206.122.1"},{"id":"0000001091-000001-c5b37","ip":"185.206.122.45/24","farmId":"","contractId":0,"gateway":"185.206.122.1"},{"id":"0000001096-000001-5f6c1","ip":"185.206.122.46/24","farmId":"","contractId":0,"gateway":"185.206.122.1"},{"id":"0000001101-000001-63193","ip":"185.206.122.47/24","farmId":"","contractId":0,"gateway":"185.206.122.1"},{"id":"0000001106-000001-c4f32","ip":"185.206.122.48/24","farmId":"","contractId":0,"gateway":"185.206.122.1"},{"id":"0000001168-000001-34245","ip":"185.206.122.49/24","farmId":"","contractId":0,"gateway":"185.206.122.1"},{"id":"0000001174-000001-db2a3","ip":"185.206.122.50/24","farmId":"","contractId":0,"gateway":"185.206.122.1"},{"id":"0000000999-000001-01080","ip":"185.206.122.34/24","farmId":"","contractId":677,"gateway":"185.206.122.1"},{"id":"0000001032-000001-5cfae","ip":"185.206.122.38/24","farmId":"","contractId":744,"gateway":"185.206.122.1"}]}`
+	FarmsExampleStr      = fmt.Sprintf("[%s]", FarmExampleStr)
+	NodeStatusExampleStr = `{"status":"up"}`
+
+	NodeExample       = MarshalNode([]byte(NodeExampleStr))
+	NodesExample      = []Node{NodeExample}
+	NodeInfoExample   = MarshalNodeInfo([]byte(NodeExampleStr))
+	FarmExample       = MarshalFarm([]byte(FarmExampleStr))
+	FarmsExample      = []Farm{FarmExample}
+	NodeStatusExample = MarshalNodeStatus([]byte(NodeStatusExampleStr))
+)
+
+func MustMarshal(data []byte, v interface{}) {
+	if err := json.Unmarshal(data, v); err != nil {
+		panic(err)
+	}
+}
+
+func MarshalNodeInfo(data []byte) (info NodeInfo) {
+	MustMarshal(data, &info)
+	return
+}
+
+func MarshalNode(data []byte) (info Node) {
+	MustMarshal(data, &info)
+	return
+}
+
+func MarshalFarm(data []byte) (info Farm) {
+	MustMarshal(data, &info)
+	return
+}
+
+func MarshalNodeStatus(data []byte) (info NodeStatus) {
+	MustMarshal(data, &info)
+	return
+}
+
+type ProxyFunc func(url string) GridProxyClient
+
+func TestConnectionFailures(t *testing.T) {
+	testConnectionFailures(t, NewGridProxyClient)
+}
+
+func testConnectionFailures(t *testing.T, f ProxyFunc) {
+	proxy := f("http://127.0.0.1:57854")
+	endpoints := map[string]func() error{
+		"ping": func() error {
+			return proxy.Ping()
+		},
+		"nodes": func() error {
+			_, err := proxy.Nodes(NodeFilter{}, Limit{})
+			return err
+		},
+		"node": func() error {
+			_, err := proxy.Node(1)
+			return err
+		},
+		"farms": func() error {
+			_, err := proxy.Farms(FarmFilter{}, Limit{})
+			return err
+		},
+		"node_status": func() error {
+			_, err := proxy.NodeStatus(1)
+			return err
+		},
+	}
+	for name, f := range endpoints {
+		if f() == nil {
+			t.Fatalf("proxy endpoint %s didn't fail for a connection-refused error", name)
+		}
+	}
+}
+
+func TestPingFailure(t *testing.T) {
+	testPingFailure(t, NewGridProxyClient)
+}
+
+func testPingFailure(t *testing.T, f ProxyFunc) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`
+		{
+			"error": "some generic error"
+		}
+	`))
+	}))
+	defer ts.Close()
+
+	proxy := f(ts.URL)
+	err := proxy.Ping()
+	if err == nil {
+		t.Fatal("ping didn't fail for a status code error")
+	}
+}
+
+func TestStatusCodeFailures(t *testing.T) {
+	testStatusCodeFailures(t, NewGridProxyClient)
+}
+
+func testStatusCodeFailures(t *testing.T, f ProxyFunc) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`
+			{
+				"error": "some generic error"
+			}
+		`))
+	}))
+	defer ts.Close()
+	proxy := f(ts.URL)
+	endpoints := map[string]func() error{
+		"nodes": func() error {
+			_, err := proxy.Nodes(NodeFilter{}, Limit{})
+			return err
+		},
+		"node": func() error {
+			_, err := proxy.Node(1)
+			return err
+		},
+		"farms": func() error {
+			_, err := proxy.Farms(FarmFilter{}, Limit{})
+			return err
+		},
+		"node_status": func() error {
+			_, err := proxy.NodeStatus(1)
+			return err
+		},
+	}
+	for name, f := range endpoints {
+		err := f()
+		if err == nil {
+			t.Fatalf("proxy endpoint %s didn't fail for a status code error", name)
+		}
+		if err.Error() != "some generic error" {
+			t.Fatalf("error parsed incorrectly in %s: %s, should be: some generic error", name, err.Error())
+		}
+	}
+}
+
+func AssertHTTPRequest(
+	t *testing.T,
+	f ProxyFunc,
+	method string,
+	path string,
+	response string,
+	call func(proxy GridProxyClient) error,
+) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expectedURL := r.URL.Path
+		if r.URL.RawQuery != "" {
+			expectedURL = fmt.Sprintf("%s?%s", expectedURL, r.URL.RawQuery)
+		}
+		if expectedURL == path && r.Method == method {
+			w.WriteHeader(http.StatusOK)
+			// panic(response)
+			w.Write([]byte(response))
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(fmt.Sprintf(`{"error": "expected path and methods: %s, %s. found: %s, %s"}`, path, method, expectedURL, r.Method)))
+		}
+	}))
+	defer ts.Close()
+	proxy := f(ts.URL)
+	err := call(proxy)
+	if err != nil {
+		log.Printf(
+			`
+			path: %s
+			response: %s
+			`,
+			path,
+			response,
+		)
+		t.Fatal(err.Error())
+	}
+}
+
+func TestSuccess(t *testing.T) {
+	testSuccess(t, NewGridProxyClient)
+}
+func testSuccess(t *testing.T, f ProxyFunc) {
+	nodesFilter, nodesLimit, expectedNodesURL := nodesFilterValues()
+	farmsFilter, farmsLimit, expectedFarmsURL := farmsFilterValues()
+	endpoints := map[string]struct {
+		method   string
+		path     string
+		response string
+		call     func(proxy GridProxyClient) error
+	}{
+		"nodes": {
+			method:   "GET",
+			path:     fmt.Sprintf("/nodes%s", expectedNodesURL),
+			response: NodesExampleStr,
+			call: func(proxy GridProxyClient) error {
+				res, err := proxy.Nodes(nodesFilter, nodesLimit)
+				if err != nil {
+					return err
+				}
+				if !reflect.DeepEqual(NodesExample, res) {
+					return fmt.Errorf("result mismatch: expected: %v, found: %v", NodesExample, res)
+				}
+				return nil
+			},
+		},
+		"node": {
+			method:   "GET",
+			path:     "/nodes/1",
+			response: NodeExampleStr,
+			call: func(proxy GridProxyClient) error {
+				res, err := proxy.Node(1)
+				if err != nil {
+					return err
+				}
+				if !reflect.DeepEqual(NodeInfoExample, res) {
+					return fmt.Errorf("result mismatch: expected: %v, found: %v", NodeInfoExample, res)
+				}
+				return nil
+			},
+		},
+		"farms": {
+			method:   "GET",
+			path:     fmt.Sprintf("/farms%s", expectedFarmsURL),
+			response: FarmsExampleStr,
+			call: func(proxy GridProxyClient) error {
+				res, err := proxy.Farms(farmsFilter, farmsLimit)
+				if err != nil {
+					return err
+				}
+				if !reflect.DeepEqual(FarmsExample, res) {
+					return fmt.Errorf("result mismatch: expected: %v, found: %v", NodeExample, res[0])
+				}
+				return nil
+			},
+		},
+		"node_status": {
+			method:   "GET",
+			path:     "/nodes/1/status",
+			response: NodeStatusExampleStr,
+			call: func(proxy GridProxyClient) error {
+				res, err := proxy.NodeStatus(1)
+				if err != nil {
+					return err
+				}
+				if !reflect.DeepEqual(NodeStatusExample, res) {
+					return fmt.Errorf("result mismatch: expected: %v, found: %v", NodeStatusExample, res)
+				}
+				return nil
+			},
+		},
+	}
+	for _, endpoint := range endpoints {
+		AssertHTTPRequest(t, f, endpoint.method, endpoint.path, endpoint.response, endpoint.call)
+	}
+}

--- a/internal/gridproxy/retrying_grid_client_test.go
+++ b/internal/gridproxy/retrying_grid_client_test.go
@@ -1,0 +1,86 @@
+package gridproxy
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type requestCounter struct {
+	Counter int
+}
+
+func NewRequestCounter() GridProxyClient {
+	return &requestCounter{0}
+}
+
+func (r *requestCounter) Ping() error {
+	r.Counter++
+	return errors.New("error")
+}
+func (r *requestCounter) Nodes(filter NodeFilter, pagination Limit) (res []Node, err error) {
+	r.Counter++
+	return nil, errors.New("error")
+}
+func (r *requestCounter) Farms(filter FarmFilter, pagination Limit) (res FarmResult, err error) {
+	r.Counter++
+	return nil, errors.New("error")
+}
+func (r *requestCounter) Node(nodeID uint32) (res NodeInfo, err error) {
+	r.Counter++
+	return NodeInfo{}, errors.New("error")
+}
+func (r *requestCounter) NodeStatus(nodeID uint32) (res NodeStatus, err error) {
+	r.Counter++
+	return NodeStatus{}, errors.New("error")
+}
+
+func retryingConstructor(u string) GridProxyClient {
+	return NewRetryingGridProxyClientWithTimeout(NewGridProxyClient(u), 1*time.Millisecond)
+}
+
+func TestRetryingConnectionFailures(t *testing.T) {
+	testConnectionFailures(t, retryingConstructor)
+}
+
+func TestRetryingPingFailure(t *testing.T) {
+	testPingFailure(t, retryingConstructor)
+}
+
+func TestRetryingStatusCodeFailures(t *testing.T) {
+	testStatusCodeFailures(t, retryingConstructor)
+}
+
+func TestRetryingSuccess(t *testing.T) {
+	testSuccess(t, retryingConstructor)
+}
+
+func TestCalledMultipleTimes(t *testing.T) {
+	r := NewRequestCounter()
+	proxy := NewRetryingGridProxyClientWithTimeout(r, 1*time.Millisecond)
+	methods := map[string]func(){
+		"nodes": func() {
+			proxy.Nodes(NodeFilter{}, Limit{})
+		},
+		"node": func() {
+			proxy.Node(1)
+		},
+		"farms": func() {
+			proxy.Farms(FarmFilter{}, Limit{})
+		},
+		"node_status": func() {
+			proxy.NodeStatus(1)
+		},
+	}
+	for endpoint, f := range methods {
+		beforeCount := r.(*requestCounter).Counter
+		f()
+		afterCount := r.(*requestCounter).Counter
+		fmt.Printf("%d %d ", beforeCount, afterCount)
+		if afterCount-beforeCount <= 1 {
+			t.Fatalf("retrying %s client is expected to try more than once. before calls: %d, after calls: %d", endpoint, beforeCount, afterCount)
+		}
+	}
+}

--- a/internal/gridproxy/types.go
+++ b/internal/gridproxy/types.go
@@ -1,7 +1,6 @@
 package gridproxy
 
 import (
-	"github.com/threefoldtech/zos/pkg/capacity/dmi"
 	"github.com/threefoldtech/zos/pkg/gridtypes"
 )
 
@@ -9,16 +8,14 @@ const NodeUP = "up"
 const NodeDOWN = "down"
 
 // capacityResult is the NodeData capacity results to unmarshal json in it
-type capacityResult struct {
+type CapacityResult struct {
 	Total gridtypes.Capacity `json:"total_resources"`
 	Used  gridtypes.Capacity `json:"used_resources"`
 }
 
 // NodeInfo is node specific info, queried directly from the node
 type NodeInfo struct {
-	Capacity   capacityResult `json:"capacity"`
-	DMI        dmi.DMI        `json:"dmi"`
-	Hypervisor string         `json:"hypervisor"`
+	Capacity CapacityResult `json:"capacity"`
 }
 
 type PublicConfig struct {
@@ -58,7 +55,7 @@ type Location struct {
 	City    string `json:"city"`
 }
 type NodeStatus struct {
-	Status string `json:"nodes"`
+	Status string `json:"status"`
 }
 
 // Nodes is struct for the whole nodes view
@@ -104,20 +101,45 @@ type PublicIP struct {
 
 type FarmResult = []Farm
 
-type farmDataV0 struct {
-	Farms []Farm `json:"farms"`
+// FarmResult is to unmarshal json in it
+
+// Limit used for pagination
+type Limit struct {
+	Size     uint64
+	Page     uint64
+	RetCount bool
 }
 
-// FarmResult is to unmarshal json in it
-type FarmResultV0 struct {
-	Data farmDataV0 `json:"data"`
+// NodeFilter node filters
+type NodeFilter struct {
+	Status       *string
+	FreeMRU      *uint64
+	FreeHRU      *uint64
+	FreeSRU      *uint64
+	Country      *string
+	City         *string
+	FarmName     *string
+	FarmIDs      []uint64
+	FreeIPs      *uint64
+	IPv4         *bool
+	IPv6         *bool
+	Domain       *bool
+	Rentable     *bool
+	RentedBy     *uint64
+	AvailableFor *uint64
 }
-type capacityResultV0 struct {
-	Total gridtypes.Capacity `json:"total"`
-	Used  gridtypes.Capacity `json:"used"`
-}
-type NodeInfoV0 struct {
-	Capacity   capacityResultV0 `json:"capacity"`
-	DMI        dmi.DMI          `json:"dmi"`
-	Hypervisor string           `json:"hypervisor"`
+
+// FarmFilter farm filters
+type FarmFilter struct {
+	FreeIPs           *uint64
+	TotalIPs          *uint64
+	StellarAddress    *string
+	PricingPolicyID   *uint64
+	Version           *uint64
+	FarmID            *uint64
+	TwinID            *uint64
+	Name              *string
+	NameContains      *string
+	CertificationType *string
+	Dedicated         *bool
 }

--- a/internal/gridproxy/utils.go
+++ b/internal/gridproxy/utils.go
@@ -1,0 +1,127 @@
+package gridproxy
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func stringifyList(l []uint64) string {
+	var ls []string
+	for _, v := range l {
+		ls = append(ls, strconv.FormatUint(v, 10))
+	}
+	return strings.Join(ls, ",")
+}
+
+func nodeParams(filter NodeFilter, limit Limit) string {
+
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "?")
+
+	if filter.Status != nil {
+		fmt.Fprintf(&builder, "status=%s&", *filter.Status)
+	}
+	if filter.FreeMRU != nil && *filter.FreeMRU != 0 {
+		fmt.Fprintf(&builder, "free_mru=%d&", *filter.FreeMRU)
+	}
+	if filter.FreeHRU != nil && *filter.FreeHRU != 0 {
+		fmt.Fprintf(&builder, "free_hru=%d&", *filter.FreeHRU)
+	}
+	if filter.FreeSRU != nil && *filter.FreeSRU != 0 {
+		fmt.Fprintf(&builder, "free_sru=%d&", *filter.FreeSRU)
+	}
+	if filter.Country != nil && *filter.Country != "" {
+		fmt.Fprintf(&builder, "country=%s&", *filter.Country)
+	}
+	if filter.City != nil && *filter.City != "" {
+		fmt.Fprintf(&builder, "city=%s&", *filter.City)
+	}
+	if filter.FarmName != nil && *filter.FarmName != "" {
+		fmt.Fprintf(&builder, "farm_name=%s&", *filter.FarmName)
+	}
+	if filter.FarmIDs != nil && len(filter.FarmIDs) != 0 {
+		fmt.Fprintf(&builder, "farm_ids=%s&", stringifyList(filter.FarmIDs))
+	}
+	if filter.FreeIPs != nil && *filter.FreeIPs != 0 {
+		fmt.Fprintf(&builder, "free_ips=%d&", *filter.FreeIPs)
+	}
+	if filter.IPv4 != nil {
+		fmt.Fprintf(&builder, "ipv4=%t&", *filter.IPv4)
+	}
+	if filter.IPv6 != nil {
+		fmt.Fprintf(&builder, "ipv6=%t&", *filter.IPv6)
+	}
+	if filter.Domain != nil {
+		fmt.Fprintf(&builder, "domain=%t&", *filter.Domain)
+	}
+	if filter.Rentable != nil {
+		fmt.Fprintf(&builder, "rentable=%t&", *filter.Rentable)
+	}
+	if filter.RentedBy != nil {
+		// passing 0 might be helpful to get available non-rented nodes
+		fmt.Fprintf(&builder, "rented_by=%d&", *filter.RentedBy)
+	}
+	if filter.AvailableFor != nil {
+		fmt.Fprintf(&builder, "available_for=%d&", *filter.AvailableFor)
+	}
+	if limit.Page != 0 {
+		fmt.Fprintf(&builder, "page=%d&", limit.Page)
+	}
+	if limit.Size != 0 {
+		fmt.Fprintf(&builder, "size=%d&", limit.Size)
+	}
+	res := builder.String()
+	// pop the extra ? or &
+	return res[:len(res)-1]
+}
+
+func farmParams(filter FarmFilter, limit Limit) string {
+
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "?")
+
+	if filter.FreeIPs != nil && *filter.FreeIPs != 0 {
+		fmt.Fprintf(&builder, "free_ips=%d&", *filter.FreeIPs)
+	}
+	if filter.TotalIPs != nil && *filter.TotalIPs != 0 {
+		fmt.Fprintf(&builder, "total_ips=%d&", *filter.TotalIPs)
+	}
+	if filter.StellarAddress != nil && *filter.StellarAddress != "" {
+		fmt.Fprintf(&builder, "stellar_address=%s&", *filter.StellarAddress)
+	}
+	if filter.PricingPolicyID != nil {
+		fmt.Fprintf(&builder, "pricing_policy_id=%d&", *filter.PricingPolicyID)
+	}
+	if filter.Version != nil {
+		fmt.Fprintf(&builder, "version=%d&", *filter.Version)
+	}
+	if filter.FarmID != nil && *filter.FarmID != 0 {
+		fmt.Fprintf(&builder, "farm_id=%d&", *filter.FarmID)
+	}
+	if filter.TwinID != nil && *filter.TwinID != 0 {
+		fmt.Fprintf(&builder, "twin_id=%d&", *filter.TwinID)
+	}
+	if filter.Name != nil && *filter.Name != "" {
+		fmt.Fprintf(&builder, "name=%s&", *filter.Name)
+	}
+	if filter.NameContains != nil && *filter.NameContains != "" {
+		fmt.Fprintf(&builder, "name_contains=%s&", *filter.NameContains)
+	}
+	if filter.CertificationType != nil && *filter.CertificationType != "" {
+		fmt.Fprintf(&builder, "certification_type=%s&", *filter.CertificationType)
+	}
+	if filter.Dedicated != nil {
+		fmt.Fprintf(&builder, "dedicated=%t&", *filter.Dedicated)
+	}
+	if limit.Page != 0 {
+		fmt.Fprintf(&builder, "page=%d&", limit.Page)
+	}
+	if limit.Size != 0 {
+		fmt.Fprintf(&builder, "size=%d&", limit.Size)
+	}
+
+	res := builder.String()
+	// pop the extra ? or &
+	return res[:len(res)-1]
+}

--- a/internal/gridproxy/utils_test.go
+++ b/internal/gridproxy/utils_test.go
@@ -1,0 +1,95 @@
+package gridproxy
+
+import "testing"
+
+func nodesFilterValues() (NodeFilter, Limit, string) {
+	Up := "up"
+	Egypt := "Egypt"
+	Mansoura := "Mansoura"
+	Freefarm := "Freefarm"
+	trueVal := true
+	falseVal := false
+	ints := []uint64{0, 1, 2, 3, 4, 5, 6}
+	f := NodeFilter{
+		Status:       &Up,
+		FreeMRU:      &ints[1],
+		FreeHRU:      &ints[2],
+		FreeSRU:      &ints[3],
+		Country:      &Egypt,
+		City:         &Mansoura,
+		FarmName:     &Freefarm,
+		FarmIDs:      []uint64{1, 2},
+		FreeIPs:      &ints[4],
+		IPv4:         &trueVal,
+		IPv6:         &falseVal,
+		Domain:       &trueVal,
+		Rentable:     &falseVal,
+		RentedBy:     &ints[5],
+		AvailableFor: &ints[6],
+	}
+	l := Limit{
+		Page: 12,
+		Size: 13,
+	}
+	return f, l, "?status=up&free_mru=1&free_hru=2&free_sru=3&country=Egypt&city=Mansoura&farm_name=Freefarm&farm_ids=1,2&free_ips=4&ipv4=true&ipv6=false&domain=true&rentable=false&rented_by=5&available_for=6&page=12&size=13"
+}
+
+func farmsFilterValues() (FarmFilter, Limit, string) {
+	StellarAddress := "StellarAddress"
+	FreeFarm := "freefarm"
+	FreeFar := "freefar"
+	DYI := "DYI"
+	Dedicated := false
+	ints := []uint64{0, 1, 2, 3, 4, 5, 6}
+	f := FarmFilter{
+		FreeIPs:           &ints[1],
+		TotalIPs:          &ints[2],
+		StellarAddress:    &StellarAddress,
+		PricingPolicyID:   &ints[3],
+		Version:           &ints[4],
+		FarmID:            &ints[5],
+		TwinID:            &ints[6],
+		Name:              &FreeFarm,
+		NameContains:      &FreeFar,
+		CertificationType: &DYI,
+		Dedicated:         &Dedicated,
+	}
+	l := Limit{
+		Page: 12,
+		Size: 13,
+	}
+
+	return f, l, "?free_ips=1&total_ips=2&stellar_address=StellarAddress&pricing_policy_id=3&version=4&farm_id=5&twin_id=6&name=freefarm&name_contains=freefar&certification_type=DYI&dedicated=false&page=12&size=13"
+}
+
+func TestNodeFilter(t *testing.T) {
+	f, l, expected := nodesFilterValues()
+	found := nodeParams(f, l)
+	if found != expected {
+		t.Fatalf("found: %s, expected: %s", found, expected)
+	}
+}
+
+func TestEmptyNodeFilter(t *testing.T) {
+	found := nodeParams(NodeFilter{}, Limit{})
+	expected := ""
+	if found != expected {
+		t.Fatalf("found: %s, expected: %s", found, expected)
+	}
+}
+
+func TestFarmFilter(t *testing.T) {
+	f, l, expected := farmsFilterValues()
+	found := farmParams(f, l)
+	if found != expected {
+		t.Fatalf("found: %s, expected: %s", found, expected)
+	}
+}
+
+func TestEmptyFarmFilter(t *testing.T) {
+	found := nodeParams(NodeFilter{}, Limit{})
+	expected := ""
+	if found != expected {
+		t.Fatalf("found: %s, expected: %s", found, expected)
+	}
+}

--- a/internal/provider/common.go
+++ b/internal/provider/common.go
@@ -224,11 +224,13 @@ func hasWorkload(dl *gridtypes.Deployment, wlType gridtypes.WorkloadType) bool {
 
 func ValidateDeployments(ctx context.Context, sub *substrate.Substrate, gridClient gridproxy.GridProxyClient, oldDeployments map[uint32]gridtypes.Deployment, newDeployments map[uint32]gridtypes.Deployment) error {
 	farmIPs := make(map[int]int)
-	allNodes, err := gridClient.Nodes()
+	// BTODO: fix
+	allNodes, err := gridClient.Nodes(gridproxy.NodeFilter{}, gridproxy.Limit{})
 	if err != nil {
 		return errors.Wrap(err, "failed to fetch nodes from the grid proxy")
 	}
-	allFarms, err := gridClient.Farms()
+	// BTODO: fix
+	allFarms, err := gridClient.Farms(gridproxy.FarmFilter{}, gridproxy.Limit{})
 	if err != nil {
 		return errors.Wrap(err, "failed to fetch farms from the grid proxy")
 	}
@@ -303,7 +305,7 @@ func ValidateDeployments(ctx context.Context, sub *substrate.Substrate, gridClie
 		}
 		mrus := nodeInfo.Capacity.Total.MRU - nodeInfo.Capacity.Used.MRU
 		hrus := nodeInfo.Capacity.Total.HRU - nodeInfo.Capacity.Used.HRU
-		srus := nodeInfo.Capacity.Total.SRU - nodeInfo.Capacity.Used.SRU
+		srus := 2*nodeInfo.Capacity.Total.SRU - nodeInfo.Capacity.Used.SRU
 		if mrus < needed.MRU ||
 			srus < needed.SRU ||
 			hrus < needed.HRU {

--- a/internal/provider/network.go
+++ b/internal/provider/network.go
@@ -53,7 +53,8 @@ func getPublicNode(ctx context.Context, gridClient gridproxy.GridProxyClient, pr
 	for _, node := range preferedNodes {
 		preferedNodesSet[node] = struct{}{}
 	}
-	nodes, err := gridClient.AliveNodes()
+	// BTODO: fix
+	nodes, err := gridClient.Nodes(gridproxy.NodeFilter{}, gridproxy.Limit{})
 	if err != nil {
 		return 0, errors.Wrap(err, "couldn't fetch nodes from the rmb proxy")
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -198,8 +198,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	apiClient.rmb = cl
 
 	grid_client := gridproxy.NewGridProxyClient(rmb_proxy_url)
-	retrying_grid_client := gridproxy.NewRetryingGridProxyClient(&grid_client)
-	apiClient.grid_client = &retrying_grid_client
+	apiClient.grid_client = gridproxy.NewRetryingGridProxyClient(grid_client)
 	if err := preValidate(&apiClient, sub); err != nil {
 		return nil, diag.FromErr(err)
 	}

--- a/internal/provider/scheduler/scheduler.go
+++ b/internal/provider/scheduler/scheduler.go
@@ -1,0 +1,112 @@
+package scheduler
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/threefoldtech/terraform-provider-grid/internal/gridproxy"
+)
+
+// NodeInfo related to scheduling
+type nodeInfo struct {
+	FreeCapacity *Capacity
+	FarmID       int
+	HasIPv4      bool
+	HasDomain    bool
+}
+
+type Scheduler struct {
+	nodes map[uint32]nodeInfo
+	// mapping from farm name to its id
+	farmIDS         map[string]int
+	gridProxyClient gridproxy.GridProxyClient
+}
+
+func NewScheduler(gridProxyClient gridproxy.GridProxyClient) Scheduler {
+	return Scheduler{
+		nodes:           map[uint32]nodeInfo{},
+		gridProxyClient: gridProxyClient,
+
+		farmIDS: make(map[string]int),
+	}
+}
+
+func (n *Scheduler) getFarmID(farmName string) (int, error) {
+	if id, ok := n.farmIDS[farmName]; ok {
+		return id, nil
+	}
+	farm, err := n.gridProxyClient.Farms(gridproxy.FarmFilter{
+		Name: &farmName,
+	}, gridproxy.Limit{
+		Size: 1,
+		Page: 1,
+	})
+	if err != nil {
+		return 0, err
+	}
+	if len(farm) == 0 {
+		return 0, fmt.Errorf("farm not found")
+	}
+	n.farmIDS[farmName] = farm[0].FarmID
+	return farm[0].FarmID, nil
+}
+
+func (n *Scheduler) getNode(r *Request) uint32 {
+	for node, cap := range n.nodes {
+		// TODO: later add free ips check when specifying the number of ips is supported
+		if fullfils(&cap, r) {
+			return node
+		}
+	}
+	return 0
+}
+
+func (n *Scheduler) addNodes(nodes []gridproxy.Node) {
+	for _, node := range nodes {
+		if _, ok := n.nodes[node.NodeID]; !ok {
+			cap := freeCapacity(&node)
+			n.nodes[node.NodeID] = nodeInfo{
+				FreeCapacity: &cap,
+				HasIPv4:      node.PublicConfig.Ipv4 != "",
+				HasDomain:    node.PublicConfig.Domain != "",
+				FarmID:       node.FarmID,
+			}
+		}
+	}
+}
+
+// Schedule makes sure there's at least one node that satisfies the given request
+func (n *Scheduler) Schedule(r *Request) (uint32, error) {
+	f := constructFilter(r)
+	l := gridproxy.Limit{
+		Size:     1,
+		Page:     1,
+		RetCount: false,
+	}
+	if r.Farm != "" {
+		id, err := n.getFarmID(r.Farm)
+		if err != nil {
+			return 0, errors.Wrapf(err, "couldn't get farm %s id", r.Farm)
+		}
+		r.farmID = id
+	}
+	node := n.getNode(r)
+	for node == 0 {
+		nodes, err := n.gridProxyClient.Nodes(f, l)
+		if err != nil {
+			return 0, errors.Wrap(err, "couldn't list nodes from the grid proxy")
+		}
+		if len(nodes) == 0 {
+			return 0, errors.New("couldn't find a node satisfying the given requirements")
+		}
+		n.addNodes(nodes)
+		node = n.getNode(r)
+		if l.Page == 1 && l.Size == 1 {
+			l.Page = 2
+		} else {
+			l.Size *= 2
+		}
+	}
+	subtract(n.nodes[node].FreeCapacity, r)
+	return node, nil
+}

--- a/internal/provider/scheduler/scheduler_test.go
+++ b/internal/provider/scheduler/scheduler_test.go
@@ -1,0 +1,343 @@
+package scheduler
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/threefoldtech/terraform-provider-grid/internal/gridproxy"
+	"github.com/threefoldtech/zos/pkg/gridtypes"
+)
+
+type GridProxyClientMock struct {
+	farms []gridproxy.Farm
+	nodes []gridproxy.Node
+}
+
+func (m *GridProxyClientMock) Ping() error {
+	return nil
+}
+
+func (m *GridProxyClientMock) Nodes(filter gridproxy.NodeFilter, pagination gridproxy.Limit) (res []gridproxy.Node, err error) {
+	start, end := (pagination.Page-1)*pagination.Size, pagination.Page*pagination.Size
+	if int(end) > len(m.nodes) {
+		end = uint64(len(m.nodes))
+	}
+	if end <= start {
+		return make([]gridproxy.Node, 0), nil
+	}
+	res = m.nodes[start:end]
+	return
+}
+
+func (m *GridProxyClientMock) Farms(filter gridproxy.FarmFilter, pagination gridproxy.Limit) (res gridproxy.FarmResult, err error) {
+	start, end := (pagination.Page-1)*pagination.Size, pagination.Page*pagination.Size
+	if int(end) > len(m.nodes) {
+		end = uint64(len(m.nodes))
+	}
+	if end <= start {
+		return make([]gridproxy.Farm, 0), nil
+	}
+	res = m.farms[start:end]
+	return
+}
+
+func (m *GridProxyClientMock) Node(nodeID uint32) (res gridproxy.NodeInfo, err error) {
+	for _, node := range m.nodes {
+		if node.NodeID == nodeID {
+			res = gridproxy.NodeInfo{
+				Capacity: gridproxy.CapacityResult{
+					Total: node.TotalResources,
+					Used:  node.UsedResources,
+				},
+			}
+			return
+		}
+	}
+	err = fmt.Errorf("node not found")
+	return
+}
+
+func (m *GridProxyClientMock) NodeStatus(nodeID uint32) (res gridproxy.NodeStatus, err error) {
+	return
+}
+
+func (m *GridProxyClientMock) AddFarm(farm gridproxy.Farm) {
+	m.farms = append(m.farms, farm)
+}
+
+func (m *GridProxyClientMock) AddNode(id uint32, node gridproxy.Node) {
+	m.nodes = append(m.nodes, node)
+}
+
+func TestSchedulerEmpty(t *testing.T) {
+	proxy := &GridProxyClientMock{}
+	scheduler := NewScheduler(proxy)
+	_, err := scheduler.Schedule(&Request{
+		Cap: Capacity{
+			Memory: 1,
+			Sru:    2,
+			Hru:    3,
+		},
+		HasIPv4:   true,
+		Name:      "req",
+		Farm:      "freefarm",
+		HasDomain: true,
+		Certified: false,
+	})
+	assert.Error(t, err, "where did you find the node?")
+}
+
+func TestSchedulerSuccess(t *testing.T) {
+	proxy := &GridProxyClientMock{}
+	proxy.AddNode(1, gridproxy.Node{
+		NodeID: 1,
+		TotalResources: gridtypes.Capacity{
+			HRU: 5,
+			SRU: 10,
+			MRU: 15,
+		},
+		UsedResources: gridtypes.Capacity{
+			HRU: 2,
+			SRU: 3,
+			MRU: 4,
+		},
+		FarmID: 1,
+		PublicConfig: gridproxy.PublicConfig{
+			Domain: "a",
+			Ipv4:   "a",
+			Ipv6:   "d",
+		},
+	})
+	proxy.AddFarm(gridproxy.Farm{
+		Name:   "freefarm",
+		FarmID: 1,
+	})
+	scheduler := NewScheduler(proxy)
+	nodeID, err := scheduler.Schedule(&Request{
+		Cap: Capacity{
+			Hru:    3,
+			Sru:    17,
+			Memory: 11,
+		},
+		HasIPv4:   true,
+		Name:      "req",
+		Farm:      "freefarm",
+		HasDomain: true,
+		Certified: false,
+	})
+	assert.NoError(t, err, "there's a satisfying node")
+	assert.Equal(t, nodeID, uint32(1), "the node id should be 1")
+}
+
+func TestSchedulerSuccessOn4thPage(t *testing.T) {
+	proxy := &GridProxyClientMock{}
+	proxy.AddNode(2, gridproxy.Node{})
+	proxy.AddNode(3, gridproxy.Node{})
+	proxy.AddNode(4, gridproxy.Node{})
+	proxy.AddNode(1, gridproxy.Node{
+		NodeID: 1,
+		TotalResources: gridtypes.Capacity{
+			HRU: 5,
+			SRU: 10,
+			MRU: 15,
+		},
+		UsedResources: gridtypes.Capacity{
+			HRU: 2,
+			SRU: 3,
+			MRU: 4,
+		},
+		FarmID: 1,
+		PublicConfig: gridproxy.PublicConfig{
+			Domain: "a",
+			Ipv4:   "a",
+			Ipv6:   "d",
+		},
+	})
+	proxy.AddFarm(gridproxy.Farm{
+		Name:   "freefarm",
+		FarmID: 1,
+	})
+	scheduler := NewScheduler(proxy)
+	nodeID, err := scheduler.Schedule(&Request{
+		Cap: Capacity{
+			Hru:    3,
+			Sru:    17,
+			Memory: 11,
+		},
+		HasIPv4:   true,
+		Name:      "req",
+		Farm:      "freefarm",
+		HasDomain: true,
+		Certified: false,
+	})
+	assert.NoError(t, err, "there's a satisfying node")
+	assert.Equal(t, nodeID, uint32(1), "the node id should be 1")
+}
+
+func TestSchedulerFailure(t *testing.T) {
+	proxy := &GridProxyClientMock{}
+	proxy.AddNode(1, gridproxy.Node{
+		NodeID: 1,
+		TotalResources: gridtypes.Capacity{
+			HRU: 5,
+			SRU: 10,
+			MRU: 15,
+		},
+		UsedResources: gridtypes.Capacity{
+			HRU: 2,
+			SRU: 3,
+			MRU: 4,
+		},
+		FarmID: 1,
+		PublicConfig: gridproxy.PublicConfig{
+			Domain: "",
+			Ipv4:   "",
+			Ipv6:   "",
+		},
+	})
+	proxy.AddFarm(gridproxy.Farm{
+		Name:   "freefarm",
+		FarmID: 1,
+	})
+
+	req := Request{
+		Cap: Capacity{
+			Hru:    3,
+			Sru:    17,
+			Memory: 11,
+		},
+		HasIPv4:   false,
+		Name:      "req",
+		Farm:      "freefarm",
+		HasDomain: false,
+		Certified: false,
+	}
+	violations := map[string]func(r *Request){
+		"mru":    func(r *Request) { r.Cap.Memory = 12 },
+		"sru":    func(r *Request) { r.Cap.Sru = 18 },
+		"hru":    func(r *Request) { r.Cap.Hru = 4 },
+		"ipv4":   func(r *Request) { r.HasIPv4 = true },
+		"domain": func(r *Request) { r.HasDomain = true },
+	}
+	for key, fn := range violations {
+		scheduler := NewScheduler(proxy)
+		cp := req
+		fn(&cp)
+		_, err := scheduler.Schedule(&cp)
+		assert.Error(t, err, fmt.Sprintf("scheduler-failure-%s", key))
+	}
+}
+func TestSchedulerFailureAfterSuccess(t *testing.T) {
+	proxy := &GridProxyClientMock{}
+	proxy.AddNode(1, gridproxy.Node{
+		NodeID: 1,
+		TotalResources: gridtypes.Capacity{
+			HRU: 5,
+			SRU: 10,
+			MRU: 15,
+		},
+		UsedResources: gridtypes.Capacity{
+			HRU: 2,
+			SRU: 3,
+			MRU: 4,
+		},
+		FarmID: 1,
+		PublicConfig: gridproxy.PublicConfig{
+			Domain: "a",
+			Ipv4:   "a",
+			Ipv6:   "d",
+		},
+	})
+	proxy.AddFarm(gridproxy.Farm{
+		Name:   "freefarm",
+		FarmID: 1,
+	})
+	scheduler := NewScheduler(proxy)
+	nodeID, err := scheduler.Schedule(&Request{
+		Cap: Capacity{
+			Hru:    2,
+			Sru:    16,
+			Memory: 10,
+		},
+		HasIPv4:   true,
+		Name:      "req",
+		Farm:      "freefarm",
+		HasDomain: true,
+		Certified: false,
+	})
+	assert.NoError(t, err, "there's a satisfying node")
+	assert.Equal(t, nodeID, uint32(1), "the node id should be 1")
+
+	_, err = scheduler.Schedule(&Request{
+		Cap: Capacity{
+			Hru:    1,
+			Sru:    1,
+			Memory: 2, // this violates
+		},
+		HasIPv4:   true,
+		Name:      "req",
+		Farm:      "freefarm",
+		HasDomain: true,
+		Certified: false,
+	})
+	assert.Error(t, err, "node would be overloaded")
+}
+
+func TestSchedulerSuccessAfterSuccess(t *testing.T) {
+	proxy := &GridProxyClientMock{}
+	proxy.AddNode(1, gridproxy.Node{
+		NodeID: 1,
+		TotalResources: gridtypes.Capacity{
+			HRU: 5,
+			SRU: 10,
+			MRU: 15,
+		},
+		UsedResources: gridtypes.Capacity{
+			HRU: 2,
+			SRU: 3,
+			MRU: 4,
+		},
+		FarmID: 1,
+		PublicConfig: gridproxy.PublicConfig{
+			Domain: "a",
+			Ipv4:   "a",
+			Ipv6:   "d",
+		},
+	})
+	proxy.AddFarm(gridproxy.Farm{
+		Name:   "freefarm",
+		FarmID: 1,
+	})
+	scheduler := NewScheduler(proxy)
+	nodeID, err := scheduler.Schedule(&Request{
+		Cap: Capacity{
+			Hru:    2,
+			Sru:    16,
+			Memory: 10,
+		},
+		HasIPv4:   true,
+		Name:      "req",
+		Farm:      "freefarm",
+		HasDomain: true,
+		Certified: false,
+	})
+	assert.NoError(t, err, "there's a satisfying node")
+	assert.Equal(t, nodeID, uint32(1), "the node id should be 1")
+
+	_, err = scheduler.Schedule(&Request{
+		Cap: Capacity{
+			Hru:    1,
+			Sru:    1,
+			Memory: 1,
+		},
+		HasIPv4:   true,
+		Name:      "req",
+		Farm:      "freefarm",
+		HasDomain: true,
+		Certified: false,
+	})
+	assert.NoError(t, err, "there's a satisfying node")
+	assert.Equal(t, nodeID, uint32(1), "the node id should be 1")
+
+}

--- a/internal/provider/scheduler/types.go
+++ b/internal/provider/scheduler/types.go
@@ -1,0 +1,18 @@
+package scheduler
+
+type Capacity struct {
+	Memory uint64
+	Sru    uint64
+	Hru    uint64
+}
+
+type Request struct {
+	Cap       Capacity
+	Name      string
+	Farm      string
+	HasIPv4   bool
+	HasDomain bool
+	Certified bool
+
+	farmID int
+}

--- a/internal/provider/scheduler/utils.go
+++ b/internal/provider/scheduler/utils.go
@@ -1,0 +1,61 @@
+package scheduler
+
+import (
+	"github.com/threefoldtech/terraform-provider-grid/internal/gridproxy"
+)
+
+var (
+	StatusUP = "up"
+	trueVal  = true
+)
+
+func freeCapacity(node *gridproxy.Node) Capacity {
+	var res Capacity
+
+	res.Memory = uint64(node.TotalResources.MRU) - uint64(node.UsedResources.MRU)
+	res.Hru = uint64(node.TotalResources.HRU) - uint64(node.UsedResources.HRU)
+	res.Sru = 2*uint64(node.TotalResources.SRU) - uint64(node.UsedResources.SRU)
+
+	return res
+}
+
+func fullfils(node *nodeInfo, r *Request) bool {
+	if r.Cap.Memory > node.FreeCapacity.Memory ||
+		r.Cap.Hru > node.FreeCapacity.Hru ||
+		r.Cap.Sru > node.FreeCapacity.Sru ||
+		(r.farmID != 0 && node.FarmID != r.farmID) ||
+		(r.HasDomain && !node.HasDomain) ||
+		(r.HasIPv4 && !node.HasIPv4) {
+		return false
+	}
+	return true
+}
+
+func subtract(node *Capacity, r *Request) {
+	node.Memory -= r.Cap.Memory
+	node.Hru -= r.Cap.Hru
+	node.Sru -= r.Cap.Sru
+}
+
+func constructFilter(r *Request) (f gridproxy.NodeFilter) {
+	f.Status = &StatusUP
+	if r.Farm != "" {
+		f.FarmName = &r.Farm
+	}
+	if r.Cap.Hru != 0 {
+		f.FreeHRU = &r.Cap.Hru
+	}
+	if r.Cap.Sru != 0 {
+		f.FreeSRU = &r.Cap.Sru
+	}
+	if r.Cap.Hru != 0 {
+		f.FreeMRU = &r.Cap.Memory
+	}
+	if r.HasDomain {
+		f.Domain = &trueVal
+	}
+	if r.HasIPv4 {
+		f.IPv4 = &trueVal
+	}
+	return f
+}

--- a/internal/provider/scheduler/utils_test.go
+++ b/internal/provider/scheduler/utils_test.go
@@ -1,0 +1,119 @@
+package scheduler
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/threefoldtech/terraform-provider-grid/internal/gridproxy"
+	"github.com/threefoldtech/zos/pkg/gridtypes"
+)
+
+var (
+	node = gridproxy.Node{
+		UsedResources: gridtypes.Capacity{
+			HRU: 1,
+			SRU: 2,
+			MRU: 3,
+		},
+		TotalResources: gridtypes.Capacity{
+			HRU: 4,
+			SRU: 5,
+			MRU: 6,
+		},
+	}
+)
+
+func TestFreeCapacity(t *testing.T) {
+	cap := freeCapacity(&node)
+	assert.Equal(t, cap.Hru, uint64(3), "hru")
+	assert.Equal(t, cap.Sru, uint64(8), "sru")
+	assert.Equal(t, cap.Memory, uint64(3), "mru")
+}
+
+func TestFullfilsSuccess(t *testing.T) {
+	cap := freeCapacity(&node)
+	nodeInfo := nodeInfo{
+		FreeCapacity: &cap,
+		FarmID:       1,
+		HasIPv4:      true,
+		HasDomain:    true,
+	}
+	assert.Equal(t, fullfils(&nodeInfo, &Request{
+		Cap: Capacity{
+			Memory: 3,
+			Sru:    8,
+			Hru:    3,
+		},
+		farmID:    1,
+		HasIPv4:   true,
+		HasDomain: false,
+	}), true, "fullfil-success")
+}
+
+func TestFullfilsFail(t *testing.T) {
+	cap := freeCapacity(&node)
+	nodeInfo := nodeInfo{
+		FreeCapacity: &cap,
+		FarmID:       1,
+		HasIPv4:      false,
+		HasDomain:    false,
+	}
+
+	req := Request{
+		Cap: Capacity{
+			Memory: 3,
+			Sru:    8,
+			Hru:    3,
+		},
+		farmID:    1,
+		HasIPv4:   false,
+		HasDomain: false,
+	}
+	violations := map[string]func(r *Request){
+		"mru":     func(r *Request) { r.Cap.Memory = 4 },
+		"sru":     func(r *Request) { r.Cap.Sru = 9 },
+		"hru":     func(r *Request) { r.Cap.Hru = 4 },
+		"farm_id": func(r *Request) { r.farmID = 2 },
+		"ipv4":    func(r *Request) { r.HasIPv4 = true },
+		"domain":  func(r *Request) { r.HasDomain = true },
+	}
+	for key, fn := range violations {
+		cp := req
+		fn(&cp)
+		assert.Equal(t, fullfils(&nodeInfo, &cp), false, fmt.Sprintf("fullfil-fail-%s", key))
+	}
+}
+
+func TestConstructFilter(t *testing.T) {
+	var farm string = "freefarm"
+	r := Request{
+		Cap: Capacity{
+			Memory: 1,
+			Sru:    2,
+			Hru:    3,
+		},
+		Name:      "a",
+		Farm:      farm,
+		HasIPv4:   true,
+		HasDomain: false,
+		Certified: true,
+	}
+
+	con := constructFilter(&r)
+	assert.Equal(t, *con.Status, "up", "construct-filter-status")
+	assert.Equal(t, *con.FreeMRU, uint64(1), "construct-filter-mru")
+	assert.Equal(t, *con.FreeSRU, uint64(2), "construct-filter-sru")
+	assert.Equal(t, *con.FreeHRU, uint64(3), "construct-filter-hru")
+	assert.Empty(t, con.Country, "construct-filter-country")
+	assert.Empty(t, con.City, "construct-filter-city")
+	assert.Equal(t, *con.FarmName, "freefarm", "construct-filter-farm-name")
+	assert.Empty(t, con.FarmIDs, "construct-filter-farm-ids")
+	assert.Empty(t, con.FreeIPs, "construct-filter-free-ips")
+	assert.Equal(t, *con.IPv4, true, "construct-filter-ipv4")
+	assert.Empty(t, con.IPv6, nil, "construct-filter-ipv6")
+	assert.Empty(t, con.Domain, nil, "construct-filter-domain")
+	assert.Empty(t, con.Rentable, nil, "construct-filter-rentable")
+	assert.Empty(t, con.RentedBy, nil, "construct-filter-rented-by")
+	assert.Empty(t, con.AvailableFor, nil, "construct-filter-available-for")
+}


### PR DESCRIPTION
- Update substrate client to print errors for deployment-on-rented-node errors
- Move the filtering and scheduling to the grid proxy