### PR TITLE
use official flists

### DIFF
--- a/examples/resources/mattermost/main.tf
+++ b/examples/resources/mattermost/main.tf
@@ -31,7 +31,7 @@
     ip_range = lookup(grid_network.net1.nodes_ip_range, 8, "")
     vms {
       name = "vm1"
-      flist = "https://hub.grid.tf/ashraf.3bot/ashraffouda-mattermost-latest.flist"
+      flist = "https://hub.grid.tf/tf-official-apps/mattermost-latest.flist"
       cpu = 2 
       entrypoint = "/sbin/zinit init"
       memory = 4096

--- a/examples/resources/peertube/main.tf
+++ b/examples/resources/peertube/main.tf
@@ -31,7 +31,7 @@
     ip_range = lookup(grid_network.net1.nodes_ip_range, 7, "")
     vms {
       name = "vm1"
-      flist = "https://hub.grid.tf/omarabdul3ziz.3bot/threefoldtech-peertube-v3.0.2.flist"
+      flist = "https://hub.grid.tf/tf-official-apps/peertube-v3.1.1.flist"
       cpu = 2 
       # publicip = true
       entrypoint = "/usr/local/bin/entrypoint.sh"

--- a/examples/resources/presearch/main.tf
+++ b/examples/resources/presearch/main.tf
@@ -31,7 +31,7 @@ resource "grid_deployment" "d1" {
 
   vms {
     name       = "presearch"
-    flist      = "https://hub.grid.tf/omarabdul3ziz.3bot/omarabdul3ziz-presearch-v2.2.flist"
+    flist      = "https://hub.grid.tf/tf-official-apps/presearch-v2.2.flist"
     entrypoint = "/sbin/zinit init"
     publicip   = true
     planetary  = true

--- a/examples/resources/taiga/main.tf
+++ b/examples/resources/taiga/main.tf
@@ -29,7 +29,7 @@ resource "grid_deployment" "node1" {
   }
   vms {
     name        = "taiga"
-    flist       = "https://hub.grid.tf/samehabouelsaad.3bot/abouelsaad-grid3_taiga_docker-latest.flist"
+    flist       = "https://hub.grid.tf/tf-official-apps/grid3_taiga_docker-latest.flist"
     entrypoint  = "/sbin/zinit init"
     cpu         = 4
     memory      = 8096

--- a/internal/provider/deployment_test.go
+++ b/internal/provider/deployment_test.go
@@ -71,7 +71,7 @@ func constructTestDeployer(ctrl *gomock.Controller) DeploymentDeployer {
 		VMs: []workloads.VM{
 			{
 				Name:          "vm1",
-				Flist:         "https://hub.grid.tf/rafybenjamin.3bot/threefolddev-discourse-v3.0.flist.md5",
+				Flist:         "https://hub.grid.tf/tf-official-apps/discourse-v4.0.flist",
 				FlistChecksum: "",
 				PublicIP:      true,
 				PublicIP6:     true,


### PR DESCRIPTION
still need to update:

1. expose vm: "https://hub.grid.tf/ashraf.3bot/strm-helloworld-http-latest.flist"
2. cosmosvalidator: "https://hub.grid.tf/ashraf.3bot/ashraffouda-threefold_hub-latest.flist"
3. external provisioner: "https://hub.grid.tf/samehabouelsaad.3bot/abouelsaad-grid3_ubuntu20.04-latest.flist"
4. external provisioner: "https://hub.grid.tf/samehabouelsaad.3bot/abouelsaad-grid3_ubuntu20.04_debug-latest.flist"
5. simple-dynamic: "https://hub.grid.tf/omar0.3bot/omarelawady-simple-http-server-latest.flist"