### PR TITLE
tag k8s module as integration and run all the tests 

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,10 +23,10 @@ testacc: submodules
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
 
 unittests: submodules
-	go test ./pkg/... && go test ./internal/...
+	go test -v ./...
 
 integrationtests: submodules
-	go test ./tests/... -p 1 --tags=integration
+	go test -v ./tests/... -p 1 --tags=integration
 
 tests: unittests integrationtests
 

--- a/tests/kubernetes_with_k8s_module/kubernetes_test.go
+++ b/tests/kubernetes_with_k8s_module/kubernetes_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package test
 
 import (


### PR DESCRIPTION
### Description

tag k8s module as integration and run all the tests 

### Changes

- Runs all tests in the unittests #465 
- Tags k8s module as  integration #466

### Related Issues


- Runs all tests in the unittests #465 
- Tags k8s module as  integration #466

### Checklist

- [x] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
