### PR TITLE
update RWMutex usage

### DIFF
--- a/internal/node/client_pool.go
+++ b/internal/node/client_pool.go
@@ -17,7 +17,7 @@ type NodeClientGetter interface {
 type NodeClientPool struct {
 	clients map[uint32]*NodeClient
 	rmb     rmb.Client
-	mux     *sync.RWMutex
+	mux     sync.RWMutex
 }
 
 // NewNodeClientPool generates a new client pool

--- a/pkg/deployer/deployer.go
+++ b/pkg/deployer/deployer.go
@@ -263,7 +263,7 @@ func (d *DeployerImpl) GetDeployments(ctx context.Context, sub subi.SubstrateExt
 	res := make(map[uint32]gridtypes.Deployment)
 
 	var wg sync.WaitGroup
-	var mux *sync.RWMutex
+	var mux = &sync.RWMutex{}
 	var resErrors error
 
 	for nodeID, dlID := range dls {


### PR DESCRIPTION
- the RWMutex pointer field on the *NodeClientPool was never initialized, and can be replaced with sync.RWMutex on its zero value
- the other one wasn't initialized