### PR TITLE
Fix gateway fqdn integration tests

### DIFF
--- a/examples/resources/gateway_fqdn/main.tf
+++ b/examples/resources/gateway_fqdn/main.tf
@@ -9,18 +9,10 @@ terraform {
 provider "grid" {
 }
 
-resource "grid_scheduler" "sched" {
-  requests {
-    name             = "gateway"
-    public_config    = true
-    public_ips_count = 1
-  }
-}
-
 resource "grid_fqdn_proxy" "p1" {
-  node     = grid_scheduler.sched.nodes["gateway"]
+  node     = 11
   name     = "workloadname"
-  fqdn     = "remote.omar.grid.tf"
+  fqdn     = "hamada1.3x0.me"
   backends = [format("http://137.184.106.152:443")]
 }
 

--- a/integrationtests/gateway_test.go
+++ b/integrationtests/gateway_test.go
@@ -67,7 +67,6 @@ func TestGateWay(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Contains(t, string(body), "Directory listing for")
 		}
-
 	})
 
 	t.Run("gateway_fqdn", func(t *testing.T) {
@@ -83,7 +82,7 @@ func TestGateWay(t *testing.T) {
 		   - Destroy the deployment
 		*/
 
-		fqdn := "hamada1.3x0.me" // points to node 15 devnet
+		fqdn := "hamada1.3x0.me" // points to node 11 devnet
 
 		terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 			TerraformDir: "./gateway_with_fqdn",
@@ -95,7 +94,9 @@ func TestGateWay(t *testing.T) {
 		defer terraform.Destroy(t, terraformOptions)
 
 		_, err := terraform.InitAndApplyE(t, terraformOptions)
-		assert.NoError(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
 
 		// Check that the outputs not empty
 		fqdn = terraform.Output(t, terraformOptions, "fqdn")

--- a/integrationtests/gateway_test.go
+++ b/integrationtests/gateway_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -81,6 +82,12 @@ func TestGateWay(t *testing.T) {
 		   - Make an http request to fqdn and assert that the response is correct.
 		   - Destroy the deployment
 		*/
+
+		// make sure the test runs only on devnet
+		if network, _ := os.LookupEnv("NETWORK"); network != "dev" {
+			t.Skip()
+			return
+		}
 
 		fqdn := "hamada1.3x0.me" // points to node 11 devnet
 

--- a/integrationtests/gateway_with_fqdn/main.tf
+++ b/integrationtests/gateway_with_fqdn/main.tf
@@ -25,10 +25,6 @@ resource "grid_scheduler" "sched" {
     sru  = 512
     mru  = 1024
   }
-  requests {
-    name          = "gateway"
-    public_config = true
-  }
 }
 
 locals {
@@ -65,7 +61,7 @@ locals {
 }
 
 resource "grid_fqdn_proxy" "p1" {
-  node            = grid_scheduler.sched.nodes["gateway"]
+  node            = 11
   name            = "test"
   fqdn            = var.fqdn
   backends        = [format("http://[%s]:9000", local.ygg_ip)]


### PR DESCRIPTION
### Changes

- remove scheduler from fqdn deployment in integration test and example
- use node 11 for gateway as the used domain `hamada1.3x0.me` is in node 11

### Related Issues
- #793 