### PR TITLE
Migrate zosbase -> zos_base module (v1.1.0)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/threefoldtech/tfgrid-sdk-go/grid-client v0.17.6
 	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.6
 	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.6
-	github.com/threefoldtech/zosbase v1.0.9
+	github.com/threefoldtech/zos_base v1.1.0
 	golang.org/x/crypto v0.49.0
 	golang.org/x/sync v0.20.0
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20210803171230-4253848d036c

--- a/go.sum
+++ b/go.sum
@@ -1339,3 +1339,5 @@ honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+github.com/threefoldtech/zos_base v1.1.0 h1:WpjxPCzEgHOkMorhkKcpqRKXnsvL4euXOBnR2IdI/AM=
+github.com/threefoldtech/zos_base v1.1.0/go.mod h1:pVOuEZ6lobb3XPmiZwrzdxahuM29hU7wKqfX+Vih1cI=

--- a/internal/provider/gateway_fqdn.go
+++ b/internal/provider/gateway_fqdn.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 // newFQDNGatewayFromSchema reads the gateway_fqdn_proxy resource configuration data from schema.ResourceData, converts them into a GatewayFQDND instance, then returns this instance.

--- a/internal/provider/gateway_name.go
+++ b/internal/provider/gateway_name.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 // newNameGatewayFromSchema reads the gateway_name_proxy resource configuration data from schema.ResourceData, converts them into a GatewayName instance, then returns this instance.

--- a/internal/provider/k8s.go
+++ b/internal/provider/k8s.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
 )
 
 // newK8sFromSchema reads the k8s resource configuration data from the schema.ResourceData, converts them into a new K8s instance, and returns this instance.

--- a/internal/provider/resource_scheduler.go
+++ b/internal/provider/resource_scheduler.go
@@ -13,7 +13,7 @@ import (
 	"github.com/threefoldtech/terraform-provider-grid/internal/provider/scheduler"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/deployer"
 	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go/peer"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
 )
 
 func resourceScheduler() *schema.Resource {


### PR DESCRIPTION
Moves the Go dependency from `github.com/threefoldtech/zosbase` to `github.com/threefoldtech/zos_base@v1.1.0` (threefoldtech/zos_base#119), removing the Go-import dependency on GitHub's rename redirect.

- `go.mod`: `zosbase v1.0.9` -> `zos_base v1.1.0`
- `go.sum` updated, imports rewritten
- `tfgrid-sdk-go`/`tfchain` deps unchanged (separate migrations)

Part of the P1 module-path migration — #2693.